### PR TITLE
Fix onboarding auth flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Local-only assistant audit notes
+/docs/local-audits/

--- a/docs/2026-04-28-onboarding-auth-remediation-plan.md
+++ b/docs/2026-04-28-onboarding-auth-remediation-plan.md
@@ -1,0 +1,234 @@
+# Beer Flow onboarding/auth remediation plan
+
+Date: 2026-04-28
+Repo: `/home/gordev/.openclaw/workspace/repos/beer-flow`
+Related local audit: `docs/local-audits/2026-04-28-beer-flow-audit-notes.md`
+Related API repo: `/home/gordev/.openclaw/workspace/repos/beer-bible-API`
+
+## Scope
+
+This plan covers the first audit's recommended fixes only:
+
+1. Fix middleware public-route allowlist.
+2. Fix invite redirect or implement the brewery detail page.
+3. Repair login form bindings/submission.
+4. Consolidate auth routes and centralize API access.
+
+Security audit items are intentionally separate, except where they directly overlap with these onboarding/auth fixes.
+
+## Current findings from repo review
+
+- `pnpm` is now available locally: `10.33.2`.
+- `src/middleware.ts` currently protects the homepage `/`, `/help`, and `/auth/create/account` because they are not excluded from the matcher.
+- `src/auth.ts` has an invite auth-flow bug: authenticated users visiting `/accept-invite` are redirected to `/auth/login?next=...`, which is backwards.
+- Unauthenticated invite users are redirected to `/auth/login` without preserving the invite URL in `next`.
+- `src/components/Invite/AcceptInvite.tsx` redirects successful invite acceptance to `/dashboard/breweries/[breweryId]`.
+- `src/app/dashboard/breweries/[breweryId]/page.tsx` currently returns `notFound()` immediately, so that success redirect lands on a 404.
+- `src/components/auth-forms/login-form.tsx` stores `email` and `password` state but the inputs do not bind to that state.
+- `login-form.tsx` also logs sign-in events and login errors, and uses button `onClick` instead of a single form `onSubmit` flow.
+- Auth/signup routes are duplicated across `/auth/[form]` and `/auth/create/account`, with `SignUpForm`, `CreateAccount`, and `login-container` overlapping.
+- API calls are mixed between `src/services/fetcher.ts`, `httpClient`, server helpers, and many direct hardcoded `https://beer-bible-api.vercel.app/...` calls.
+
+## Recommended implementation order
+
+### Phase 1 — Middleware and invite flow unblocker
+
+Goal: make public onboarding routes reachable and make invite links preserve intent.
+
+Changes:
+
+1. Replace the fragile negative-regex matcher in `src/middleware.ts` with a clearer public-route allowlist pattern.
+2. Public routes should include at least:
+   - `/`
+   - `/help`
+   - `/privacy-policy`
+   - `/auth/login`
+   - `/auth/signup`
+   - `/auth/create/account` temporarily, until consolidated
+   - `/accept-invite`
+   - static assets and image files
+3. In `src/auth.ts` authorized callback:
+   - If unauthenticated and visiting `/accept-invite`, redirect to `/auth/login?next=<full invite URL>`.
+   - If unauthenticated and visiting any other protected route, redirect to `/auth/login`.
+   - If authenticated, allow `/accept-invite` through instead of redirecting back to login.
+4. Verify invite query strings are preserved across login/signup.
+
+Acceptance checks:
+
+- Logged-out users can open `/`, `/help`, `/auth/login`, `/auth/signup`, `/auth/create/account`, and `/accept-invite?token=test`.
+- Logged-out protected routes still redirect to `/auth/login`.
+- Logged-out invite route redirects to login with a `next` param containing the original invite URL.
+- Logged-in invite route renders the invite acceptance page.
+
+### Phase 2 — Brewery detail route fix
+
+Goal: stop successful invite acceptance and normal navigation from landing on a guaranteed 404.
+
+Recommendation: implement the brewery detail page instead of changing the invite redirect.
+
+Reason:
+
+- Multiple existing links already point to `/dashboard/breweries/[breweryId]`.
+- Redirecting only the invite flow to `/beers` would hide the broader broken route.
+- `BreweryProfiles` and `getSingleBrewery` already exist and appear intended for this page.
+
+Changes:
+
+1. Update `src/app/dashboard/breweries/[breweryId]/page.tsx` to fetch brewery data from the API.
+2. Render brewery beer/category overview using the existing UI where practical.
+3. Return `notFound()` only when the API returns a true missing/unauthorized state.
+4. Keep successful invite redirect as `/dashboard/breweries/${breweryId}` if the page is implemented.
+5. If page implementation is too large for the first PR, temporary fallback may redirect to `/dashboard/breweries/${breweryId}/beers`, but that should be documented as temporary.
+
+Acceptance checks:
+
+- `/dashboard/breweries/[validId]` no longer always 404s.
+- Invite acceptance lands on a usable brewery page.
+- Existing nav links to brewery root work.
+- Invalid or unauthorized brewery IDs show not-found or a clear error state.
+
+### Phase 3 — Login form repair
+
+Goal: make email/password login actually submit entered credentials and behave predictably.
+
+Changes:
+
+1. Convert login to a single `onSubmit` handler on the `<form>`.
+2. Call `event.preventDefault()`.
+3. Bind email input:
+   - `value={email}`
+   - `onChange={(event) => setEmail(event.target.value)}`
+   - `name="email"`
+   - `autoComplete="email"`
+4. Bind password input:
+   - `value={password}`
+   - `onChange={(event) => setPassword(event.target.value)}`
+   - `name="password"`
+   - `autoComplete="current-password"`
+5. Disable submit while credentials login is loading.
+6. Use `router.push(...)` instead of client `redirect(...)` from event handlers.
+7. Remove sensitive console logging from this form as part of this fix.
+8. Preserve `next` redirects after successful credentials or Google sign-in.
+
+Acceptance checks:
+
+- Email/password form submits the values typed by the user.
+- Empty fields are blocked by browser validation and/or client validation.
+- Failed login stays on login page and shows one user-safe error.
+- Successful login redirects to `next` when present, otherwise `/dashboard/overview`.
+- Google sign-in keeps the same callback behavior.
+
+### Phase 4 — Consolidate auth routes
+
+Goal: reduce duplicate auth/signup UX without changing the product model.
+
+Jordan note: Beer Flow uses NextAuth for provider and email logins only. Google likely needs setup again later; Supabase image setup is a separate follow-up.
+
+Recommendation:
+
+- Make `/auth/[form]` the canonical auth route for now:
+  - `/auth/login`
+  - `/auth/signup`
+- Preserve `/auth/create/account` as a compatibility redirect to `/auth/signup`, carrying through the `next` query param.
+- Remove or retire duplicated `CreateAccount` / `login-container` flows only after verifying feature parity with `SignUpForm` and `LoginForm`.
+
+Changes:
+
+1. Add a redirect from `/auth/create/account` to `/auth/signup`, preserving query params.
+2. Update homepage/help links from `/auth/create/account` to `/auth/signup`.
+3. Ensure signup links preserve `next` when coming from invite flow.
+4. Keep only Google/provider and email login language in the UI.
+5. Do not add GitHub login unless Jordan explicitly asks.
+
+Acceptance checks:
+
+- `/auth/create/account?next=...` redirects to `/auth/signup?next=...`.
+- Homepage/help CTA links go to the canonical signup route.
+- Login/signup screens use consistent layout and copy.
+- Invite flow can move from login to signup without losing `next`.
+
+### Phase 5 — Centralize API access
+
+Goal: stop spreading hardcoded API URLs and create one place to reason about Beer Bible API calls.
+
+Recommendation:
+
+1. Standardize on one base URL env var:
+   - server: `API_URL`
+   - optional browser-safe public fallback only if truly needed: `NEXT_PUBLIC_API_URL`
+2. Create a central API module, likely under `src/lib/api/`, with typed endpoint helpers for:
+   - auth/users
+   - breweries
+   - beers
+   - categories
+   - staff/invites
+3. Move hardcoded `https://beer-bible-api.vercel.app` calls behind that module incrementally.
+4. Prefer server-side calls for authenticated API access.
+5. Where client components need mutations, use server actions or small Next route handlers so bearer token handling remains server-controlled in the later security pass.
+6. Keep `/api/message` out of this plan because Jordan said it is unused.
+
+Initial high-impact files to migrate:
+
+- `src/components/auth-forms/sign-up-form.tsx`
+- `src/components/CreateAccount/CreateAccount.tsx`
+- `src/components/Invite/AcceptInvite.tsx`
+- `src/lib/POST/acceptInvite.ts`
+- `src/lib/POST/sendInvite.ts`
+- `src/lib/createBrewery.tsx`
+- `src/lib/createCategory.tsx`
+- `src/lib/getAllBreweries.tsx`
+- `src/lib/getAllUsers.tsx`
+- `src/lib/getSingleBrewery.tsx`
+- `src/lib/getSingleBeer.tsx`
+- `src/lib/DELETE/*`
+- `src/lib/PATCH/*`
+- `src/lib/PUT/*`
+
+Acceptance checks:
+
+- No new code uses hardcoded `https://beer-bible-api.vercel.app` URLs.
+- Existing central fetcher handles base URL, JSON headers, auth header, response parsing, and safe error messages.
+- Build/lint remain at least no worse than before.
+- A grep for the hardcoded API URL shows a shrinking list and eventually zero app runtime callers.
+
+## Suggested PR breakdown
+
+1. PR 1: Middleware allowlist + invite authorized callback + login form bindings.
+2. PR 2: Brewery root page implementation or temporary redirect fallback.
+3. PR 3: Auth route consolidation and CTA/link cleanup.
+4. PR 4+: API client centralization by domain, starting with invite/auth/brewery helpers.
+
+This keeps the most user-visible onboarding breakages isolated from the larger API cleanup.
+
+## Validation commands
+
+Run after each PR-sized change:
+
+```bash
+pnpm install
+pnpm lint
+pnpm build
+```
+
+Manual smoke checks:
+
+```text
+/logged out: /
+/logged out: /help
+/logged out: /auth/login
+/logged out: /auth/signup
+/logged out: /accept-invite?token=fake
+/logged in: /accept-invite?token=real-or-test
+/logged in: /dashboard/breweries/<breweryId>
+/login form: credentials success/failure
+/login form: Google callback preserves next
+```
+
+## Open decisions before coding
+
+1. Should `/dashboard/breweries/[breweryId]` be the canonical brewery overview page, or should it redirect to `/dashboard/breweries/[breweryId]/beers`?
+   - Recommendation: implement it as the canonical overview page.
+2. During auth route consolidation, is it okay to remove the old `CreateAccount` flow after parity is confirmed?
+   - Recommendation: first redirect it, then remove dead code in a later cleanup PR.
+3. Should API centralization immediately force all authenticated calls server-side, or should that be paired with the token/session security pass?
+   - Recommendation: centralize now, then fully server-side/token-minimize in the security pass.

--- a/docs/2026-04-28-security-remediation-plan.md
+++ b/docs/2026-04-28-security-remediation-plan.md
@@ -1,0 +1,317 @@
+# Beer Flow security remediation plan
+
+Date: 2026-04-28
+Repo: `/home/gordev/.openclaw/workspace/repos/beer-flow`
+Related local audit: `docs/local-audits/2026-04-28-beer-flow-audit-notes.md`
+Related prior plan: `docs/2026-04-28-onboarding-auth-remediation-plan.md`
+Related API repo: `/home/gordev/.openclaw/workspace/repos/beer-bible-API`
+
+## Scope
+
+This plan covers the security audit recommended fixes:
+
+1. Remove/rotate exposed OAuth secrets.
+2. Remove sensitive auth/signup logging.
+3. Keep refresh/access tokens out of client-visible session data.
+4. Lock down `/api/message` with auth, rate limits, size caps, and server-controlled roles.
+5. Fix invite token handling and login/signup redirects.
+6. Centralize server-side authorization for tenant/brewery ownership.
+
+Jordan note from the saved audit: `/api/message` is currently unused, so it is not a product blocker. If it remains in the codebase, it should still be made safe before exposure or use.
+
+## Current findings from repo review
+
+### 1. OAuth secrets exposure
+
+`next.config.js` still exposes provider secrets through `module.exports.env`:
+
+- `GITHUB_SECRET`
+- `GOOGLE_CLIENT_SECRET`
+- Also exposes provider IDs that do not need to be manually inlined.
+
+This should be removed. NextAuth can read server-only env vars directly from `process.env` in server code.
+
+Follow-up outside code:
+
+- Rotate any Google/GitHub OAuth secret that may have been deployed while exposed.
+- Reconfigure Google provider credentials after rotation.
+
+### 2. Sensitive auth/signup logging
+
+Remaining sensitive/noisy logs found:
+
+- `src/components/auth-forms/sign-up-form.tsx`
+  - logs full signup form data, including password and confirm password.
+  - logs signup response payload.
+- `src/lib/GET/getUserByCredentials.tsx`
+  - logs email/password and full returned user data.
+- `src/components/CreateAccount/CreateAccount.tsx`
+  - logs create-account error response data; route is now redirected but code remains.
+- `src/auth.ts`
+  - logs sign-in error messages; less severe, but should be normalized to safe server logging.
+- Other non-auth console logs exist, but the first pass should focus on auth/signup/password/user payload logs.
+
+### 3. Client-visible token/session exposure
+
+`src/auth.ts` currently signs app access/refresh tokens and copies both into `session.user`:
+
+- `session.user.accessToken`
+- `session.user.refreshToken`
+
+`src/types/users.ts` and `src/types/next-auth.d.ts` model access/refresh tokens as user/session fields, which encourages client usage.
+
+Many client components call API helpers with `session.user.accessToken`, so fully removing this requires an incremental server-side proxy/action migration.
+
+### 4. `/api/message` exposure
+
+`src/app/api/message/route.ts` currently:
+
+- accepts unauthenticated POST requests.
+- parses arbitrary JSON without size/shape guard before body read.
+- maps client-provided messages into OpenAI roles based on `isUserMessage`.
+- lacks rate limiting.
+- lacks request size caps.
+- streams OpenAI output to caller.
+
+Even though unused, it should be either disabled or hardened before public deployment.
+
+### 5. Invite token handling and login/signup redirects
+
+The onboarding remediation already improved:
+
+- unauthenticated invite users redirect to login with `next` preserved.
+- authenticated invite users are allowed through.
+- login form preserves `next`.
+- `/auth/create/account` redirects to `/auth/signup`.
+
+Remaining security issue:
+
+- invite tokens are still passed in URL query strings (`/accept-invite?token=...`) and forwarded to the API query string.
+- Query string tokens can leak through logs, browser history, referrers, analytics, and screenshots.
+
+API compatibility needs checking before changing this, because Beer Bible API currently exposes `/accept-invite?token=...`.
+
+### 6. Tenant/brewery authorization
+
+Current frontend architecture still relies heavily on:
+
+- browser/session-visible `selectedBreweryId`.
+- `localStorage` selected brewery values.
+- client-visible bearer tokens.
+- client-side API calls for brewery/beer/category/staff mutations.
+
+This should move toward server-side authorization wrappers that derive identity from the server session and validate brewery membership/role before mutation.
+
+## Recommended implementation order
+
+### Phase 1 — Remove exposed secrets and sensitive logging
+
+Goal: eliminate obvious secret leaks and password/form-data logs without broad architecture changes.
+
+Changes:
+
+1. Remove `env` block from `next.config.js` for OAuth secrets/IDs.
+   - Do not expose `GITHUB_SECRET` or `GOOGLE_CLIENT_SECRET` via Next config.
+   - Keep provider credentials server-only in `.env`/deployment environment.
+2. Remove or sanitize auth/signup logs:
+   - `src/components/auth-forms/sign-up-form.tsx`
+   - `src/lib/GET/getUserByCredentials.tsx`
+   - `src/components/CreateAccount/CreateAccount.tsx` if retained temporarily.
+   - `src/auth.ts` sign-in error logging should avoid raw provider/API details when possible.
+3. Replace sensitive logs with user-safe toast messages and optional development-only sanitized diagnostics.
+4. Add a short `docs/security-operations.md` note or checklist for rotating exposed OAuth secrets.
+
+Acceptance checks:
+
+- `next.config.js` no longer contains `GOOGLE_CLIENT_SECRET`, `GITHUB_SECRET`, or provider env passthrough.
+- `grep` finds no password/form-data credential logging in auth/signup code.
+- Signup and credentials login still work against existing API in dev.
+- `pnpm lint` and `pnpm build` pass or are no worse than baseline.
+
+### Phase 2 — Minimize browser-visible session data
+
+Goal: stop exposing refresh tokens and broad sensitive user objects to the browser.
+
+Recommended approach:
+
+1. Immediate safe reduction:
+   - Remove `refreshToken` from `session.user`.
+   - Remove `refreshToken` from `src/types/next-auth.d.ts` session/user type.
+   - Remove `refreshToken` from `src/types/users.ts` user model unless it is genuinely returned by the API and needed server-side.
+2. Keep any API access token server-side where possible.
+3. If an access token must remain temporarily for existing client calls, document it as a temporary compatibility bridge and remove it only after server route/action migration.
+4. Narrow JWT payload creation in `src/lib/jwt.ts` / `src/auth.ts`:
+   - Do not sign the full user object.
+   - Use minimal claims: user id, email if needed, brewery ids, selected brewery id, role/permissions if available.
+   - Never include password, refresh token, full notifications object unless needed.
+5. Move token refresh logic out of client-visible session callbacks.
+
+Acceptance checks:
+
+- Browser session payload no longer includes `refreshToken`.
+- JWT payload no longer signs full API user objects.
+- Type definitions no longer encourage client refresh-token usage.
+- Existing screens that rely on `session.user.accessToken` remain functional until Phase 4 migration removes that dependency.
+
+### Phase 3 — Lock down or disable `/api/message`
+
+Goal: remove unauthenticated OpenAI proxy risk.
+
+Recommended option for now: disable by default unless explicitly enabled.
+
+Changes:
+
+1. Add an env guard such as `ENABLE_MESSAGE_API=true`.
+   - If not enabled, return `404` or `403`.
+2. Require authentication using `auth()` before processing.
+3. Add request body size protection.
+   - Prefer route/runtime config or manual byte-length cap before JSON parsing.
+   - Suggested cap: 8–16 KB unless product requirements need more.
+4. Validate schema strictly.
+   - Cap number of messages.
+   - Cap text length per message and total text length.
+5. Server-control roles.
+   - Treat all caller-provided content as user text.
+   - Never allow callers to set OpenAI `system`, `assistant`, or arbitrary roles.
+6. Add rate limiting.
+   - Use existing Upstash dependencies if configured.
+   - Key by authenticated user id first, IP fallback second.
+7. Return safe errors only.
+
+Acceptance checks:
+
+- Unauthenticated `/api/message` request is rejected.
+- Oversized request is rejected.
+- Caller cannot inject non-user/system roles.
+- Rate-limit path is covered or the endpoint is disabled until rate-limit env is configured.
+- If Jordan confirms it is unused, endpoint can be disabled entirely in production.
+
+### Phase 4 — Invite token hardening
+
+Goal: reduce invite token leakage without breaking Beer Bible API compatibility.
+
+Changes:
+
+1. Confirm API support in `beer-bible-API`.
+   - Current API appears to use `/accept-invite?token=...`.
+2. Preferred target architecture:
+   - frontend invite link contains a short opaque code only.
+   - Next route handler receives the code and exchanges/accepts server-side.
+   - token is stored/forwarded server-side, not kept in long-lived client URLs.
+3. Incremental app-only improvement if API cannot change yet:
+   - After reading token from URL, immediately replace browser history state to remove `?token=...`.
+   - Avoid logging token anywhere.
+   - Ensure redirects preserve invite intent without duplicating token unnecessarily.
+4. Better API change, if allowed later:
+   - add `POST /accept-invite` with token in request body or one-time server exchange.
+   - make invite tokens short-lived and single-use.
+
+Acceptance checks:
+
+- Invite acceptance still works.
+- Token is not logged by frontend code.
+- Browser URL is cleaned after token capture where feasible.
+- Long-term API change is documented if not implemented in this repo.
+
+### Phase 5 — Server-side authorization and mutation migration
+
+Goal: prevent client-controlled brewery IDs/tokens from becoming the authorization source.
+
+Recommended architecture:
+
+1. Create server-side API wrappers/route handlers/server actions for mutations:
+   - create/update/delete beer
+   - create/update/delete category
+   - staff invite/remove/admin toggle
+   - brewery profile update/delete
+   - notification preference update
+2. Each server-side mutation should:
+   - call `auth()` to get the server session.
+   - derive user id and brewery membership from server-owned session/JWT claims or backend API lookup.
+   - validate the requested `breweryId` belongs to the current user.
+   - validate owner/admin permission for privileged actions.
+   - call Beer Bible API server-side with server-held auth token.
+3. Keep `selectedBreweryId` as UI state only, not an authorization decision.
+4. Avoid trusting `localStorage` for authorization or mutation ownership.
+5. Migrate by domain to reduce risk:
+   - staff/admin operations first.
+   - brewery profile/delete next.
+   - beer/category mutations next.
+
+Acceptance checks:
+
+- Client mutation code no longer passes raw bearer tokens.
+- Server checks user/brewery relationship before mutation.
+- Staff/admin actions require admin/owner role server-side.
+- Bad brewery IDs fail even if manually supplied from the browser.
+
+### Phase 6 — Medium-priority hardening pass
+
+Goal: address remaining audit issues after the critical/high pass.
+
+Changes:
+
+1. Add security headers/CSP in `next.config.js` or middleware.
+   - Start report-only if needed, then enforce.
+2. Remove `typescript.ignoreBuildErrors: true` after baseline TS errors are fixed.
+3. Move upload validation server-side.
+4. Verify markdown/external-link URL scheme sanitization and add tests/helpers if missing.
+5. Add anti-automation controls to signup/public routes.
+6. Fix or remove malformed `/api/users` route.
+
+Acceptance checks:
+
+- Build does not ignore TypeScript errors.
+- Security headers are present in production responses.
+- Uploads are validated server-side.
+- Signup endpoint has basic abuse resistance.
+
+## Suggested PR breakdown
+
+1. PR 1: Remove client-exposed secrets + remove sensitive auth/signup logging + add secret-rotation checklist.
+2. PR 2: Remove refresh token from client session and narrow JWT payloads.
+3. PR 3: Disable or harden `/api/message`.
+4. PR 4: Invite token cleanup/history replacement + API follow-up doc if backend change needed.
+5. PR 5+: Server-side authorization migration by domain, starting with staff/admin and brewery mutations.
+6. PR 6+: Medium-priority security headers, TypeScript build strictness, upload validation, `/api/users` cleanup.
+
+## Validation commands
+
+Run after each PR-sized change:
+
+```bash
+pnpm lint
+pnpm build
+```
+
+Useful grep checks:
+
+```bash
+grep -RIn "GOOGLE_CLIENT_SECRET\|GITHUB_SECRET" next.config.js src || true
+grep -RIn "console\.log.*password\|console\.log.*Form Data\|console\.log.*credentials\|console\.log.*User data" src || true
+grep -RIn "refreshToken" src/auth.ts src/types src/components src/app || true
+grep -RIn "session\.user\.accessToken" src/components src/app src/context || true
+```
+
+Manual smoke checks:
+
+```text
+/signup: email account create success/failure
+/login: credentials success/failure
+/login: Google sign-in callback
+/invite: logged-out invite preserves next
+/invite: logged-in invite acceptance
+/api/message: unauthenticated request rejected or endpoint disabled
+/dashboard brewery mutations: staff/admin actions still work after server migration
+```
+
+## Open decisions before coding
+
+1. Should `/api/message` be disabled entirely for now?
+   - Recommendation: yes, disable by default and only re-enable behind auth/rate-limit/env guard if the product uses it later.
+2. Is it acceptable to remove `refreshToken` from client session immediately while leaving `accessToken` temporarily until server-side mutation migration is complete?
+   - Recommendation: yes. Removing refresh token now is low risk; removing access token needs staged migration.
+3. Can Beer Bible API be changed for safer invite acceptance?
+   - Recommendation: eventually add a POST/body or server-side exchange flow. For this repo pass, clean the browser URL and avoid token logging.
+4. Should the first server-side authorization migration target staff/admin or beer/category mutations?
+   - Recommendation: staff/admin first because privilege changes are higher impact.

--- a/src/app/auth/create/account/page.tsx
+++ b/src/app/auth/create/account/page.tsx
@@ -1,15 +1,22 @@
-import CreateAccount from "@/components/CreateAccount/CreateAccount";
-import LoginPageSkeleton from "@/components/skeletons/login-page-skeleton";
-import React, { Suspense } from "react";
+import { redirect } from "next/navigation";
 
-type Props = {};
+type Props = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
 
-const CreateAccountPage = (props: Props) => {
-  return (
-    <div className="w-full h-full mx-auto">
-      <CreateAccount />
-    </div>
-  );
+const CreateAccountPage = ({ searchParams }: Props) => {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams || {})) {
+    if (typeof value === "string") {
+      params.set(key, value);
+    } else if (Array.isArray(value)) {
+      value.forEach((entry) => params.append(key, entry));
+    }
+  }
+
+  const query = params.toString();
+  redirect(query ? `/auth/signup?${query}` : "/auth/signup");
 };
 
 export default CreateAccountPage;

--- a/src/app/dashboard/breweries/[breweryId]/page.tsx
+++ b/src/app/dashboard/breweries/[breweryId]/page.tsx
@@ -1,16 +1,47 @@
+import { auth } from "@/auth";
 import BreweryProfiles from "@/components/BreweryProfiles";
+import getBreweryBeers from "@/lib/getBreweryBeers";
 import getSingleBrewery from "@/lib/getSingleBrewery";
+import { notFound } from "next/navigation";
 
-import { notFound, redirect } from "next/navigation";
-
-type pageProps = {
+type PageProps = {
   params: {
     breweryId: string;
   };
 };
 
-export default async function SingleBreweryPage({ params }: pageProps) {
-  const { breweryId } = await params;
+export default async function SingleBreweryPage({ params }: PageProps) {
+  const { breweryId } = params;
+  const session = await auth();
 
-  return notFound();
+  if (!session?.user?.accessToken) {
+    notFound();
+  }
+
+  const [brewery, beers] = await Promise.all([
+    getSingleBrewery([
+      `/breweries/${breweryId}`,
+      session.user.accessToken,
+    ]),
+    getBreweryBeers([
+      `/breweries/${breweryId}/beers`,
+      session.user.accessToken,
+    ]),
+  ]);
+
+  if (!brewery?._id) {
+    notFound();
+  }
+
+  const categories = Array.isArray(brewery.categories)
+    ? brewery.categories
+    : [];
+  const breweryBeers =
+    Array.isArray(beers) && beers.length > 0 ? beers : brewery.beers || [];
+
+  return (
+    <div className="w-full h-full">
+      <BreweryProfiles categories={categories} data={breweryBeers} />
+    </div>
+  );
 }

--- a/src/app/help/layout.tsx
+++ b/src/app/help/layout.tsx
@@ -25,7 +25,7 @@ const layout = async ({ children }: Props) => {
               Log In
             </Link>
             <Link
-              href="/auth/create/account"
+              href="/auth/signup"
               className=" flex justify-center items-center w-full rounded-full bg-accent hover:shadow-xl transition-all ease-in-out text-sm  text-primary shadow-sm font-medium hover:bg-[#68cdc0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
             >
               Sign up

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,7 @@ export default async function Home() {
                   Log In
                 </Link>
                 <Link
-                  href="/auth/create/account"
+                  href="/auth/signup"
                   className=" flex justify-center items-center w-full h-3/4 rounded-full bg-accent hover:shadow-xl transition-all ease-in-out text-sm  text-primary shadow-sm font-medium hover:bg-[#68cdc0] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
                 >
                   Sign up
@@ -104,7 +104,7 @@ export default async function Home() {
                 <GoogleSignInButton title="Sign up with Google" />
 
                 <Link
-                  href="/auth/create/account"
+                  href="/auth/signup"
                   className=" flex justify-center items-center w-full md:w-1/2 rounded-full bg-primary hover:shadow-xl transition-all ease-in-out px-3.5 py-2.5 text-sm  text-background shadow-sm hover:bg-[#1e1e1e] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white gap-2"
                 >
                   <Mail size={24} strokeWidth={1} color="#f7f4ea" /> Sign up

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -47,8 +47,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         email: { label: "Email address", type: "text", placeholder: "email" },
         password: { label: "Password", type: "password" },
       },
-      async authorize(credentials, req) {
-        console.log("Credentials login", credentials, req);
+      async authorize(credentials, _req) {
         if (!credentials?.email) {
           throw new Error("Email address is required");
         }
@@ -71,7 +70,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             selectedBreweryId: null,
           };
         } catch (error: any) {
-          console.error("Login error:", error.message);
           throw new Error(error.message);
         }
       },
@@ -94,7 +92,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       profile?: Profiles | undefined;
       account?: Account | null;
     }): Promise<boolean> {
-      const name = user?.name ?? profile?.name;
       const email = user?.email ?? profile?.email;
       const picture = profile?.picture ?? user?.image;
       const cookieStore = await cookies();
@@ -144,17 +141,37 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     }) => {
       const isAuth = !!auth?.user;
       const acceptInvite = nextUrl.pathname.startsWith("/accept-invite");
-      if (!isAuth) {
-        return NextResponse.redirect(new URL("/auth/login", nextUrl));
+      const publicRoutes = [
+        "/",
+        "/help",
+        "/privacy-policy",
+        "/auth/login",
+        "/auth/signup",
+        "/auth/create/account",
+      ];
+
+      if (
+        publicRoutes.some(
+          (route) =>
+            nextUrl.pathname === route || nextUrl.pathname.startsWith(`${route}/`)
+        )
+      ) {
+        return true;
       }
 
-      if (isAuth && acceptInvite) {
+      if (!isAuth) {
         const loginUrl = new URL("/auth/login", nextUrl);
-        loginUrl.searchParams.set("next", nextUrl.toString());
+        if (acceptInvite) {
+          loginUrl.searchParams.set("next", nextUrl.toString());
+        }
         return NextResponse.redirect(loginUrl);
       }
 
-      return true; // Example: Return true if auth exists, otherwise false
+      if (acceptInvite) {
+        return true;
+      }
+
+      return true;
     },
     async jwt({
       token,

--- a/src/components/Invite/AcceptInvite.tsx
+++ b/src/components/Invite/AcceptInvite.tsx
@@ -1,12 +1,9 @@
 "use client";
 import { Brewery } from "@/types/brewery";
-import { useBreweryContext } from "@/context/brewery-beer";
 import { useToast } from "@/context/toast";
+import { buildApiUrl } from "@/lib/api/base";
 import { acceptInvite } from "@/lib/POST/acceptInvite";
-import getBreweries from "@/lib/getBreweries";
-import getSingleBrewery from "@/lib/getSingleBrewery";
 import { useSession } from "next-auth/react";
-import { revalidatePath } from "next/cache";
 import Link from "next/link";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -59,10 +56,9 @@ const AcceptInvite = (props: Props) => {
       }
     };
 
-    mutate(
-      "https://beer-bible-api.vercel.app/users/breweries",
-      fetcher("https://beer-bible-api.vercel.app/users/breweries")
-    );
+    const breweryListUrl = buildApiUrl("/users/breweries");
+
+    mutate(breweryListUrl, fetcher(breweryListUrl));
   };
 
   const fetchInvite = async (token: string) => {

--- a/src/components/auth-forms/login-form.tsx
+++ b/src/components/auth-forms/login-form.tsx
@@ -1,13 +1,13 @@
 "use client";
-import { cn } from "@/lib/utils";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import SaveButton from "@/components/Buttons/SaveButton";
+import { cn } from "@/lib/utils";
 import { Loader2 } from "lucide-react";
-import { signIn, SignInResponse, useSession } from "next-auth/react";
+import { signIn } from "next-auth/react";
 import Link from "next/link";
-import { redirect, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
@@ -15,71 +15,81 @@ export function LoginForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"form">) {
+  const router = useRouter();
   const searchParams = useSearchParams();
-  const { data: session } = useSession();
 
-  const [isGoogleLoading, setIsGoogleLoading] = useState<boolean>(false);
-  const [isCreateLoading, setIsCreateLoading] = useState<boolean>(false);
-  const [email, setEmail] = useState<string>("");
-  const [password, setPassword] = useState<string>("");
-  const [loginError, setLoginError] = useState<any>(null);
-  const [acceptInviteUrl, setAcceptInviteUrl] = useState<string | null>(null);
+  const [isGoogleLoading, setIsGoogleLoading] = useState(false);
+  const [isCreateLoading, setIsCreateLoading] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const next = searchParams.get("next");
-
-  const onSignIn = async (e: any, provider: string) => {
-    setLoginError(null);
-    console.log(e, provider);
-    try {
-      if (provider === "google") {
-        setIsGoogleLoading(true);
-        const result = await signIn("google", {
-          callbackUrl: acceptInviteUrl || "/dashboard/overview",
-        });
-        const res = result as unknown as SignInResponse;
-
-        if (res?.error) {
-          toast.error(res.error);
-        }
-        return;
-      }
-
-      if (provider === "credentials") {
-        setIsCreateLoading(true);
-        const login = await signIn("credentials", {
-          email,
-          password,
-          redirect: false,
-          callbackUrl: acceptInviteUrl || "/dashboard/overview",
-        });
-
-        if (!login || !login.ok) {
-          console.log("Login error!!!:", login);
-          setLoginError(login?.error?.split(":")[1]);
-          setIsCreateLoading(false);
-          toast.error(
-            "There was an error logging in. Please check your credentials and try again."
-          );
-          redirect("/auth/login");
-        }
-
-        sessionStorage.setItem("credentialsLogin", "true");
-        redirect(acceptInviteUrl || "/dashboard/overview");
-      }
-    } catch (error: any) {
-      setLoginError(error);
-    } finally {
-      setIsGoogleLoading(false);
-    }
-  };
+  const [acceptInviteUrl, setAcceptInviteUrl] = useState<string | null>(next);
+  const callbackUrl = acceptInviteUrl || "/dashboard/overview";
 
   useEffect(() => {
     if (next) {
       setAcceptInviteUrl(next);
     }
-  }, []);
+  }, [next]);
+
+  const onSignIn = async (provider: "google" | "credentials") => {
+    try {
+      if (provider === "google") {
+        setIsGoogleLoading(true);
+        const result = await signIn("google", {
+          callbackUrl,
+        });
+
+        if (result?.error) {
+          toast.error(result.error);
+        }
+
+        return;
+      }
+
+      setIsCreateLoading(true);
+
+      const login = await signIn("credentials", {
+        email,
+        password,
+        redirect: false,
+        callbackUrl,
+      });
+
+      if (!login || !login.ok) {
+        toast.error(
+          "There was an error logging in. Please check your credentials and try again."
+        );
+        return;
+      }
+
+      sessionStorage.setItem("credentialsLogin", "true");
+      const destination = login.url || callbackUrl;
+      const resolvedDestination = destination.startsWith("http")
+        ? (() => {
+            const parsedUrl = new URL(destination);
+            return parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
+          })()
+        : destination;
+
+      router.push(resolvedDestination);
+    } catch {
+      toast.error("There was an error logging in. Please try again.");
+    } finally {
+      setIsGoogleLoading(false);
+      setIsCreateLoading(false);
+    }
+  };
 
   return (
-    <form className={cn("flex flex-col gap-6", className)} {...props}>
+    <form
+      className={cn("flex flex-col gap-6", className)}
+      onSubmit={(event) => {
+        event.preventDefault();
+        void onSignIn("credentials");
+      }}
+      {...props}
+    >
       <div className="flex flex-col items-center gap-2 text-center">
         <h1 className="text-2xl font-bold">Login to your account</h1>
         <p className="text-balance text-sm text-muted-foreground">
@@ -91,7 +101,7 @@ export function LoginForm({
           variant="outline"
           className="w-full"
           type="button"
-          onClick={(e) => onSignIn(e, "google")}
+          onClick={() => void onSignIn("google")}
           disabled={isGoogleLoading}
         >
           {isGoogleLoading ? (
@@ -135,7 +145,16 @@ export function LoginForm({
         </div>
         <div className="grid gap-2">
           <Label htmlFor="email">Email</Label>
-          <Input id="email" type="email" placeholder="m@example.com" required />
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="m@example.com"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
         </div>
         <div className="grid gap-2">
           <div className="flex items-center">
@@ -147,13 +166,20 @@ export function LoginForm({
               Forgot your password?
             </a>
           </div>
-          <Input id="password" type="password" required />
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            required
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
         </div>
-        <Button
-          type="submit"
-          className="w-full"
-          onClick={(e) => onSignIn(e, "credentials")}
-        >
+        <Button type="submit" className="w-full" disabled={isCreateLoading}>
+          {isCreateLoading ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : null}
           Login
         </Button>
       </div>

--- a/src/components/auth-forms/sign-up-form.tsx
+++ b/src/components/auth-forms/sign-up-form.tsx
@@ -18,6 +18,7 @@ import { useSearchParams } from "next/navigation";
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
+import { buildApiUrl } from "@/lib/api/base";
 
 // 1. Zod schema
 const formSchema = z
@@ -38,7 +39,9 @@ export function SignUpForm() {
   const searchParams = useSearchParams();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isGoogleLoading, setIsGoogleLoading] = useState<boolean>(false);
-  const [acceptInviteUrl, setAcceptInviteUrl] = useState<string | null>(null);
+  const [acceptInviteUrl, setAcceptInviteUrl] = useState<string | null>(
+    searchParams.get("next")
+  );
 
   useEffect(() => {
     const next = searchParams.get("next");
@@ -60,7 +63,7 @@ export function SignUpForm() {
     console.log("Form Data", data);
     try {
       const response = await fetch(
-        "https://beer-bible-api.vercel.app/users/credentials/create",
+        buildApiUrl("/users/credentials/create"),
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/src/lib/POST/acceptInvite.ts
+++ b/src/lib/POST/acceptInvite.ts
@@ -1,3 +1,5 @@
+import { buildApiUrl } from "@/lib/api/base";
+
 type pageProps = {
   token: string | string[];
   accessToken: string;
@@ -5,8 +7,11 @@ type pageProps = {
 export const acceptInvite = async ({ token, accessToken }: pageProps) => {
   try {
     if (token && accessToken) {
+      const inviteToken = Array.isArray(token) ? token[0] : token;
       const response = await fetch(
-        `https://beer-bible-api.vercel.app/accept-invite?token=${token}`,
+        `${buildApiUrl("/accept-invite")}?token=${encodeURIComponent(
+          inviteToken
+        )}`,
         {
           method: "GET",
           headers: {

--- a/src/lib/POST/sendInvite.ts
+++ b/src/lib/POST/sendInvite.ts
@@ -1,4 +1,5 @@
 // apiService.ts
+import { buildApiUrl } from "@/lib/api/base";
 
 interface Invite {
   email: string;
@@ -16,20 +17,17 @@ export async function sendInvite({
   accessToken,
 }: Props) {
   if (breweryId && accessToken) {
-    const response = await fetch(
-      `https://beer-bible-api.vercel.app/breweries/${breweryId}/invite`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        },
-        body: JSON.stringify({
-          email: inviteData.email,
-          isAdmin: inviteData.isAdmin,
-        }),
-      }
-    );
+    const response = await fetch(buildApiUrl(`/breweries/${breweryId}/invite`), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        email: inviteData.email,
+        isAdmin: inviteData.isAdmin,
+      }),
+    });
 
     // Check if the response is JSON before calling response.json()
     if (response.headers.get("Content-Type")?.includes("application/json")) {

--- a/src/lib/api/base.ts
+++ b/src/lib/api/base.ts
@@ -1,0 +1,22 @@
+const DEFAULT_API_BASE_URL = "https://beer-bible-api.vercel.app";
+
+export function getApiBaseUrl() {
+  return (
+    process.env.API_URL ??
+    process.env.NEXT_PUBLIC_API_URL ??
+    DEFAULT_API_BASE_URL
+  );
+}
+
+export function buildApiUrl(path: string) {
+  if (!path) {
+    throw new Error("API path is required");
+  }
+
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return new URL(normalizedPath, getApiBaseUrl()).toString();
+}

--- a/src/lib/getBreweryBeers.tsx
+++ b/src/lib/getBreweryBeers.tsx
@@ -1,14 +1,13 @@
 "use server";
 import { auth } from "@/auth";
-
-type pageProps = [url: string, token: string];
+import { buildApiUrl } from "@/lib/api/base";
 
 export default async function getBreweryBeers([url, token]: any) {
   const user = await auth();
 
   if (user?.user) {
     try {
-      const response = await fetch(url, {
+      const response = await fetch(buildApiUrl(url), {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${user?.user.accessToken}`,

--- a/src/lib/getSingleBrewery.tsx
+++ b/src/lib/getSingleBrewery.tsx
@@ -1,22 +1,23 @@
 "use server";
 
 import { auth } from "@/auth";
-
-type pageProps = [url: string, token: string];
+import { buildApiUrl } from "@/lib/api/base";
 
 export default async function getSingleBrewery([url, token]: any) {
   const user = await auth();
-  if (user?.user) {
+  const accessToken = token || user?.user?.accessToken;
+
+  if (accessToken) {
     try {
-      const response = await fetch(url, {
+      const response = await fetch(buildApiUrl(url), {
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${user.user.accessToken}`,
+          Authorization: `Bearer ${accessToken}`,
         },
         method: "GET",
       });
 
-      if (response.status != 200) {
+      if (!response.ok) {
         throw new Error(response.statusText);
       }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,15 @@
 export const config = {
+  // api, _next/static, _next/image, favicon.ico, and static assets are intentionally not included in the explicit matcher list.
   matcher: [
-    // "/api/:path*",
-    "/((?!api|_next(?:/static|/image)|favicon\\.ico|privacy-policy|auth/login|auth/signup|accept-invite|.*\\.(?:svg|png|jpg|jpeg|webp|gif|ico)$).*)",
+    "/",
+    "/help/:path*",
+    "/privacy-policy",
+    "/auth/login",
+    "/auth/signup",
+    "/auth/create/account",
+    "/accept-invite",
+    "/dashboard/:path*",
+    "/settings/:path*",
   ],
 };
 export { auth as middleware } from "@/auth";

--- a/src/services/fetcher.ts
+++ b/src/services/fetcher.ts
@@ -1,7 +1,6 @@
 "use server";
 import { auth } from "@/auth";
-
-const baseUrl = process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL;
+import { buildApiUrl } from "@/lib/api/base";
 
 export const fetcher = async (endpoint: string, options: RequestInit = {}) => {
   const session = await auth();
@@ -19,7 +18,7 @@ export const fetcher = async (endpoint: string, options: RequestInit = {}) => {
   };
 
   try {
-    const res = await fetch(baseUrl + endpoint, config);
+    const res = await fetch(buildApiUrl(endpoint), config);
 
     if (!res.ok) {
       if (res.status === 400) {


### PR DESCRIPTION
## Summary
- fix public route/auth middleware behavior for onboarding and invite links
- implement brewery root page so accepted invites no longer redirect to a guaranteed 404
- repair credentials login form bindings/submission and preserve invite `next` redirects
- consolidate `/auth/create/account` into canonical `/auth/signup`
- add shared API base helper and migrate touched auth/invite/brewery helpers
- add remediation plan docs while keeping local audit notes ignored

## Verification
- `pnpm lint` passes with existing `react-hooks/exhaustive-deps` warnings
- `pnpm build` passes with existing warning about `BeerViewDialog` export mismatch in `BreweryProfiles.tsx`

## Notes
- This PR intentionally does not address the full security audit implementation; that will be stacked on a follow-up branch.
- `.codex` remains untracked locally and was not included.
