### PR TITLE
Add product remediation workflows

### DIFF
--- a/docs/2026-04-28-product-remediation-plan.md
+++ b/docs/2026-04-28-product-remediation-plan.md
@@ -1,0 +1,368 @@
+# Beer Flow Product Remediation Plan
+
+Date: 2026-04-28
+Scope: Product audit follow-up for Beer Flow after onboarding/auth and security remediation.
+
+## Goal
+
+Close the highest-value product workflow gaps without starting broad platform rewrites. The focus is on features directly called out by the product audit and already scaffolded in the app: import/export, share-after-create, real brewery analytics, and operational notifications.
+
+## Non-goals for this pass
+
+- Do not build audit/activity history yet.
+- Do not build granular RBAC yet.
+- Do not build external social/mobile integrations yet.
+- Do not do a broad API/data-layer rewrite beyond what the selected product fixes require.
+- Do not treat `/api/message` as part of this product pass.
+
+## Current findings from the saved audit and repo inspection
+
+### 1. Bulk import exists as a UI scaffold only
+
+Current state:
+
+- `src/components/FlatfilePortal/FlatfilePortal.tsx` opens Flatfile, validates/transforms records, and downloads a CSV template.
+- `onSubmit` currently only logs imported rows:
+  - `console.log("onSubmit", data);`
+- `src/flatfile/blueprint.js` defines beer fields that mostly map to the Beer model.
+- The API currently supports single beer creation at `POST /breweries/:breweryId/beers`, but no dedicated bulk import endpoint was found.
+
+Product impact:
+
+- The app advertises upload/import behavior, but imported rows are not persisted.
+
+### 2. Export is missing beyond template download
+
+Current state:
+
+- `FlatfilePortal` can download a sample/template CSV.
+- The overview page has a generic `Download` button with static dashboard content.
+- No real brewery beer export flow was found.
+
+Product impact:
+
+- Breweries can enter data but cannot easily extract their beer list for operations, reporting, or migration.
+
+### 3. Analytics are static/dashboard-placeholder content
+
+Current state:
+
+- `src/features/overview/components/overview.tsx` shows sales/revenue/subscription-style cards with static numbers that do not fit the brewery product.
+- Graph components and “Recent Sales” are placeholder-style content.
+- The product already has enough beer/brewery fields for useful first-pass metrics: total beers, active vs archived, category mix, release cadence, missing images, and recently released beers.
+
+Product impact:
+
+- Dashboard does not reflect the actual brewery state and can reduce trust.
+
+### 4. No share flow after beer creation
+
+Current state:
+
+- Beer creation succeeds, mutates local data, clears the form, and shows a toast.
+- There is no post-create action sheet/modal for copying a beer link or navigating to the new beer.
+- Existing app routes include beer detail routes under brewery beer paths, so an internal share/copy link is feasible before public beer pages exist.
+
+Product impact:
+
+- Creating a beer is a dead-end workflow instead of a launch/share workflow.
+
+### 5. Notification preferences exist, but events do not appear wired
+
+Current state:
+
+- Notification preferences exist in `src/types/notifications.ts` and `src/components/Settings/NotificationSettings.tsx`.
+- API has a notification-settings update endpoint.
+- No clear product event pipeline was found for beer create/update/archive.
+
+Product impact:
+
+- Users can configure preferences, but product events do not clearly trigger notifications.
+
+## Recommended implementation order
+
+### Phase 1 — Make import/export real
+
+Why first:
+
+- Highest value from the audit.
+- The UI scaffold already exists.
+- It turns incomplete promises into complete workflow loops.
+
+#### 1A. Add a frontend import normalization layer
+
+Create a dedicated import mapper that converts Flatfile records into the existing Beer create payload shape.
+
+Suggested location:
+
+- `src/lib/import/beerImport.ts`
+
+Responsibilities:
+
+- Convert Flatfile keys to app/API field names:
+  - `name` -> `name`
+  - `style` -> `style`
+  - `abv` -> `abv`
+  - `ibu` -> `ibu`
+  - `category` -> category lookup/create flow
+  - `malts` -> `malt`
+  - `hops` -> `hops`
+  - `description` -> `description`
+  - `name_sake` -> `nameSake`
+  - `notes` -> `notes`
+  - `release_date` -> `releasedOn`
+  - `archived` -> `archived`
+- Enforce required fields before calling the API.
+- Return per-row success/error results for the UI.
+
+#### 1B. Persist imported rows
+
+Recommended first implementation:
+
+- Keep API changes minimal.
+- Submit valid rows from the frontend using the existing `POST /breweries/:breweryId/beers` endpoint.
+- Process rows sequentially or with a small concurrency limit to avoid overwhelming the API.
+- Show an import summary after submit:
+  - created count
+  - failed count
+  - row-level errors
+
+Potential follow-up if imports are large:
+
+- Add a Beer Bible API bulk endpoint later: `POST /breweries/:breweryId/beers/bulk`.
+- Use one transaction-like server path for category creation and beer creation.
+
+#### 1C. Handle categories during import
+
+Recommended first behavior:
+
+- Match category names case-insensitively against existing brewery categories.
+- If category does not exist and current user is owner/admin, create it via existing category endpoint before creating the beer.
+- If category creation fails, mark that row failed and continue other rows.
+
+Open question before build:
+
+- Should imported unknown categories be auto-created, or should import require categories to already exist?
+
+Recommendation:
+
+- Auto-create categories for owner/admin users because it makes bulk import dramatically more useful.
+
+#### 1D. Add real export
+
+Add an export control near the existing import/template controls.
+
+Initial export options:
+
+- Export all beers for selected brewery.
+- Export filtered/current visible beers if the table/list already has filters available.
+- Include archived flag.
+
+CSV columns should mirror import template where possible:
+
+- Name
+- Style
+- ABV
+- IBU
+- Category
+- Malts
+- Hops
+- Description
+- Name Sake
+- Notes
+- Release Date
+- Archived
+
+Implementation note:
+
+- Start client-side using already fetched brewery beer data.
+- If dataset size becomes a problem, move export generation server/API-side later.
+
+### Phase 2 — Add a post-create share flow
+
+Why second:
+
+- Small, high-visibility product improvement.
+- Builds on existing beer creation path.
+
+#### 2A. After create, keep the new beer response and show actions
+
+Update beer create flows so success does not only clear and toast.
+
+After a beer is created, show one of:
+
+- a lightweight success modal
+- a toast with actions
+- a slide-over/share sheet
+
+Recommended first version:
+
+- Success modal or toast action with:
+  - “View beer”
+  - “Copy link”
+  - “Create another”
+
+#### 2B. Use internal beer links first
+
+Use the existing internal route shape for copy/view:
+
+- `/dashboard/breweries/{breweryId}/beers/{beerId}`
+
+Do not build public beer pages in this pass.
+
+Future follow-up:
+
+- Public beer pages with OG metadata for customer-facing sharing.
+
+### Phase 3 — Replace placeholder analytics with real brewery metrics
+
+Why third:
+
+- The dashboard currently looks generic/static.
+- Real metrics can be derived from current brewery/beer data without major backend work.
+
+#### 3A. Define first-pass metrics
+
+Replace sales/revenue cards with brewery-relevant cards:
+
+- Total beers
+- Active beers
+- Archived beers
+- Categories
+- New releases this month
+- Beers missing images/content, if useful
+
+#### 3B. Replace placeholder charts
+
+Use actual beer data for:
+
+- Category mix pie/bar chart
+- Release cadence by month
+- Active vs archived ratio
+- Recent beers/releases list
+
+#### 3C. Data source
+
+Use the currently selected brewery and existing beer/category fetches.
+
+If needed, add a small local analytics utility:
+
+- `src/lib/analytics/breweryMetrics.ts`
+
+Keep the first version frontend/server-component derived. Avoid adding new API endpoints unless performance or data availability requires it.
+
+### Phase 4 — Wire operational notification events
+
+Why fourth:
+
+- Preferences already exist, but event delivery needs product semantics and probably API/email decisions.
+- More cross-system risk than import/export/share/analytics.
+
+#### 4A. Define events
+
+Start with:
+
+- beer created / released
+- beer updated
+- beer archived
+
+Use current preferences:
+
+- `notifications.allow`
+- `notifications.newBeerRelease.email`
+- `notifications.newBeerRelease.push`
+- `notifications.beerUpdate.email`
+- `notifications.beerUpdate.push`
+
+#### 4B. Decide event execution location
+
+Recommendation:
+
+- Server/API side should own notification dispatch because events must be trustworthy and should not depend on a browser staying open.
+
+Possible first cut:
+
+- Beer Bible API triggers notification emails when beer create/update/archive succeeds.
+- Frontend only displays local success toasts.
+
+#### 4C. Keep push out unless infrastructure exists
+
+If no push notification infrastructure is configured, treat push preferences as stored settings only and implement email notifications first.
+
+## Suggested PR breakdown
+
+### PR 1 — Product import/export foundation
+
+- Add import normalization utility.
+- Persist Flatfile submitted rows to the Beer Bible API.
+- Add import summary UI.
+- Add CSV export for selected brewery beers.
+- Keep implementation scoped to existing endpoints unless category auto-create requires current category endpoint use.
+
+Verification:
+
+- `pnpm lint`
+- `pnpm build`
+- Manual import of sample CSV creates beers.
+- Exported CSV can round-trip into import with expected field mapping.
+
+### PR 2 — Beer create share flow
+
+- Add post-create success actions.
+- Copy internal beer link.
+- Add “View beer” navigation.
+
+Verification:
+
+- `pnpm lint`
+- `pnpm build`
+- Manual create beer -> copy/view/create another all work.
+
+### PR 3 — Real overview analytics
+
+- Replace static sales/revenue cards with brewery metrics.
+- Replace placeholder charts/lists with derived beer/category data.
+
+Verification:
+
+- `pnpm lint`
+- `pnpm build`
+- Manual dashboard check with breweries containing active/archived beers and categories.
+
+### PR 4 — Notification event design / first implementation
+
+- Document event rules.
+- Implement server-side email event for the least risky first event, likely beer created/released.
+- Honor stored preferences.
+
+Verification:
+
+- API route/unit smoke check if API is changed.
+- Frontend build if frontend settings display changes.
+- Manual create/update/archive event test in a non-production environment.
+
+## API considerations
+
+Immediate frontend-only product work can start without API changes by using existing endpoints:
+
+- `POST /breweries/:breweryId/beers`
+- `POST /breweries/:breweryId/categories`
+- `GET /breweries/:breweryId/beers`
+- `GET /breweries/:breweryId`
+
+Likely API improvements for later or larger imports:
+
+- Bulk beer import endpoint.
+- Bulk category lookup/create endpoint.
+- Server-generated export endpoint.
+- Server-side notification event dispatch for beer lifecycle events.
+
+## Recommended next action
+
+Start with PR 1: import/export foundation.
+
+Before implementation, confirm one product decision:
+
+- Should imported unknown categories be auto-created for owner/admin users?
+
+My recommendation is yes: auto-create categories during import, with per-row failure reporting if creation fails.

--- a/src/app/dashboard/overview/@area_stats/page.tsx
+++ b/src/app/dashboard/overview/@area_stats/page.tsx
@@ -1,5 +1,5 @@
 import { AreaGraph } from "@/features/overview/components/area-graph";
 
-export default async function AreaStats() {
+export default function AreaStats() {
   return <AreaGraph />;
 }

--- a/src/app/dashboard/overview/@bar_stats/page.tsx
+++ b/src/app/dashboard/overview/@bar_stats/page.tsx
@@ -1,8 +1,5 @@
-import { delay } from "@/constants/mock-api";
 import { BarGraph } from "@/features/overview/components/bar-graph";
 
-export default async function BarStats() {
-  await await delay(1000);
-
+export default function BarStats() {
   return <BarGraph />;
 }

--- a/src/app/dashboard/overview/@pie_stats/page.tsx
+++ b/src/app/dashboard/overview/@pie_stats/page.tsx
@@ -1,5 +1,5 @@
 import { PieGraph } from "@/features/overview/components/pie-graph";
 
-export default async function Stats() {
+export default function Stats() {
   return <PieGraph />;
 }

--- a/src/app/dashboard/overview/@sales/page.tsx
+++ b/src/app/dashboard/overview/@sales/page.tsx
@@ -1,5 +1,5 @@
 import { RecentSales } from "@/features/overview/components/recent-sales";
 
-export default async function Sales() {
+export default function Sales() {
   return <RecentSales />;
 }

--- a/src/app/dashboard/overview/layout.tsx
+++ b/src/app/dashboard/overview/layout.tsx
@@ -1,14 +1,5 @@
 import PageContainer from "@/components/layout/page-container";
-import { Badge } from "@/components/ui/badge";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardAction,
-  CardFooter,
-} from "@/components/ui/card";
-import { TrendingDown, TrendingUp } from "lucide-react";
+import OverviewSummary from "@/features/overview/components/overview";
 
 import React from "react";
 
@@ -31,97 +22,7 @@ export default function OverViewLayout({
             Hi, Welcome back 👋
           </h2>
         </div>
-
-        <div className="*:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card grid grid-cols-1 gap-4 *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:shadow-xs md:grid-cols-2 lg:grid-cols-4">
-          <Card className="@container/card">
-            <CardHeader>
-              <CardDescription>Total Revenue</CardDescription>
-              <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-                $1,250.00
-              </CardTitle>
-              <CardAction>
-                <Badge variant="outline">
-                  <TrendingUp />
-                  +12.5%
-                </Badge>
-              </CardAction>
-            </CardHeader>
-            <CardFooter className="flex-col items-start gap-1.5 text-sm">
-              <div className="line-clamp-1 flex gap-2 font-medium">
-                Trending up this month <TrendingUp className="size-4" />
-              </div>
-              <div className="text-muted-foreground">
-                Visitors for the last 6 months
-              </div>
-            </CardFooter>
-          </Card>
-          <Card className="@container/card">
-            <CardHeader>
-              <CardDescription>New Customers</CardDescription>
-              <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-                1,234
-              </CardTitle>
-              <CardAction>
-                <Badge variant="outline">
-                  <TrendingDown />
-                  -20%
-                </Badge>
-              </CardAction>
-            </CardHeader>
-            <CardFooter className="flex-col items-start gap-1.5 text-sm">
-              <div className="line-clamp-1 flex gap-2 font-medium">
-                Down 20% this period <TrendingDown className="size-4" />
-              </div>
-              <div className="text-muted-foreground">
-                Acquisition needs attention
-              </div>
-            </CardFooter>
-          </Card>
-          <Card className="@container/card">
-            <CardHeader>
-              <CardDescription>Active Accounts</CardDescription>
-              <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-                45,678
-              </CardTitle>
-              <CardAction>
-                <Badge variant="outline">
-                  <TrendingUp />
-                  +12.5%
-                </Badge>
-              </CardAction>
-            </CardHeader>
-            <CardFooter className="flex-col items-start gap-1.5 text-sm">
-              <div className="line-clamp-1 flex gap-2 font-medium">
-                Strong user retention <TrendingUp className="size-4" />
-              </div>
-              <div className="text-muted-foreground">
-                Engagement exceed targets
-              </div>
-            </CardFooter>
-          </Card>
-          <Card className="@container/card">
-            <CardHeader>
-              <CardDescription>Growth Rate</CardDescription>
-              <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-                4.5%
-              </CardTitle>
-              <CardAction>
-                <Badge variant="outline">
-                  <TrendingUp />
-                  +4.5%
-                </Badge>
-              </CardAction>
-            </CardHeader>
-            <CardFooter className="flex-col items-start gap-1.5 text-sm">
-              <div className="line-clamp-1 flex gap-2 font-medium">
-                Steady performance increase <TrendingUp className="size-4" />
-              </div>
-              <div className="text-muted-foreground">
-                Meets growth projections
-              </div>
-            </CardFooter>
-          </Card>
-        </div>
+        <OverviewSummary />
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-7">
           <div className="col-span-4">{bar_stats}</div>
           <div className="col-span-4 md:col-span-3">

--- a/src/components/CreateBeerForm/CreateBeerForm.tsx
+++ b/src/components/CreateBeerForm/CreateBeerForm.tsx
@@ -1,10 +1,8 @@
 "use client";
-import { Brewery } from "@/types/brewery";
 import handleCreateBeer from "@/lib/handleSubmit/handleCreateBeer";
 import { hopSuggestions, maltSuggestions } from "@/lib/suggestionsDB";
 import validateFields from "@/lib/validators/forms";
-import { useRouter } from "next/navigation";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import CategorySelect from "../CategorySelect/CategorySelect";
 import ErrorField from "../ErrorField/ErrorField";
 import TagInput from "../TagInput/TagInput";
@@ -21,14 +19,35 @@ import TrashCanIcon from "../Buttons/TrashCanIcon";
 import SaveButton from "../Buttons/SaveButton";
 import DefaultBeerImage from "../../assets/img/beer.png";
 import getSingleBrewery from "@/lib/getSingleBrewery";
-import { spawn } from "child_process";
+import BeerPostCreateShare from "../beers/beer-post-create-share";
 
-type pageProps = {};
+type pageProps = {
+  setIsCreateBeer?: React.Dispatch<React.SetStateAction<boolean>>;
+};
 
-const CreateBeerForm = ({}: pageProps) => {
-  const { data: session, status, update } = useSession();
+const getEmptyValues = (): FormValues => ({
+  name: "",
+  abv: "",
+  ibu: "",
+  style: "",
+  malt: [],
+  hops: [],
+  description: "",
+  category: [],
+  nameSake: "",
+  notes: "",
+  image: null,
+  releasedOn: "",
+  archived: false,
+});
+
+const CreateBeerForm = (props: pageProps) => {
+  const { setIsCreateBeer } = props;
+  void setIsCreateBeer;
+  const { data: session } = useSession();
 
   const { selectedBeers, selectedBrewery, isAdmin } = useBreweryContext();
+  const [createdBeer, setCreatedBeer] = useState<Beer | null>(null);
 
   const { mutate } = useSWR(
     [
@@ -50,21 +69,7 @@ const CreateBeerForm = ({}: pageProps) => {
 
   const [isClearing, setIsClearing] = useState<boolean>(false); // Track if form is being cleared
 
-  const [values, setValues] = useState<FormValues>({
-    name: "",
-    abv: "",
-    ibu: "",
-    style: "",
-    malt: [],
-    hops: [],
-    description: "",
-    category: [],
-    nameSake: "",
-    notes: "",
-    image: null,
-    releasedOn: "",
-    archived: false,
-  });
+  const [values, setValues] = useState<FormValues>(getEmptyValues());
 
   // Define a new state to track "touched" status for each field
   const [touched, setTouched] = useState<{ [K in keyof FormValues]: boolean }>({
@@ -83,9 +88,14 @@ const CreateBeerForm = ({}: pageProps) => {
     archived: false,
   });
 
-  const router = useRouter();
   const { addToast } = useToast();
   const isSubmitting = useRef(false);
+
+  useEffect(() => {
+    if (createdBeer) {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  }, [createdBeer]);
 
   // Create a map that connects field names to their refs
   const fieldRefs: RefsType = {
@@ -99,6 +109,7 @@ const CreateBeerForm = ({}: pageProps) => {
   // Handle form submission
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setCreatedBeer(null);
     isSubmitting.current = true;
     // Mark all fields as touched
     setTouched({
@@ -147,6 +158,7 @@ const CreateBeerForm = ({}: pageProps) => {
           mutate([...(selectedBeers as Beer[]), newBeerRes]);
           mutateBrewery();
           handleClear(); // Clear the form
+          setCreatedBeer(newBeerRes);
           addToast(`${newBeerRes.name} successfully created!`, "success");
         }
       }
@@ -165,21 +177,7 @@ const CreateBeerForm = ({}: pageProps) => {
 
   const handleClear = () => {
     setIsClearing(true); // Set to true at the start of clearing
-    setValues({
-      name: "",
-      abv: "",
-      ibu: "",
-      style: "",
-      malt: [],
-      hops: [],
-      description: "",
-      category: [],
-      nameSake: "",
-      notes: "",
-      image: null,
-      releasedOn: "",
-      archived: false,
-    });
+    setValues(getEmptyValues());
 
     setTouched({
       name: false,
@@ -199,6 +197,7 @@ const CreateBeerForm = ({}: pageProps) => {
 
     sessionStorage.removeItem("beerForm"); // Remove the saved form
     setPreviewImage(null);
+    setCreatedBeer(null);
     setIsClearing(false); // Set to false at the end of clearing
   };
 
@@ -223,7 +222,7 @@ const CreateBeerForm = ({}: pageProps) => {
     sessionStorage.setItem("beerForm", JSON.stringify(values));
     // Clear the error message when the form fields change
     setSubmitError(null);
-  }, [values]);
+  }, [values, isClearing]);
 
   return isAdmin ? (
     <form
@@ -246,6 +245,15 @@ const CreateBeerForm = ({}: pageProps) => {
           <X size={20} strokeWidth={1} />
         </button>
       </div>
+      {createdBeer && selectedBrewery?._id && (
+        <div className="px-2 md:px-4 pt-2">
+          <BeerPostCreateShare
+            beer={createdBeer}
+            sharePath={`/dashboard/breweries/${selectedBrewery._id}/beers/${createdBeer._id}`}
+            onCreateAnother={handleClear}
+          />
+        </div>
+      )}
       <div className="flex flex-col md:flex-row-reverse justify-between p-2 md:p-4 ">
         {/*  Beer Image */}
         <div className="flex flex-col items-center justify-between w-full md:w-[45%] p-2 pt-4 md:pt-2">

--- a/src/components/FlatfilePortal/FlatfilePortal.tsx
+++ b/src/components/FlatfilePortal/FlatfilePortal.tsx
@@ -1,178 +1,328 @@
 "use client";
-import React from "react";
-import blueprint from "../../flatfile/blueprint";
-import { Sheet, useFlatfile } from "@flatfile/react";
-import moment from "moment";
-import { Beer } from "@/types/beer";
-type Props = {};
 
-const generateCSVTemplate = (blueprint) => {
-  const headers = blueprint.fields.map((field) => field.label).join(",") + "\n";
-  const exampleRows = [
-    [
-      "Example Beer Name",
-      "IPA",
-      "7.5",
-      "70",
-      "Hoppy",
-      "Malt1 Malt2",
-      "Hop1 Hop2",
-      "Freshest of the fresh hops",
-      "One that was made up buy the great master minds",
-      "Double Dry hopped with Citra and Mosaic",
-      "2019-03-05",
-      "false",
-    ],
-    [
-      "Another Beer Name",
-      "Stout",
-      "5.6",
-      "30",
-      "Dark & Malty",
-      "Malt1 Malt2",
-      "Hop1 Hop2",
-      "Dark Chocolatey and Delicious",
-      "One that was made up buy the great master minds... again",
-      "Collaboration with the brewery down the street",
-      "2019-03-05",
-      "true",
-    ],
-  ];
-  const rows = exampleRows.map((row) => row.join(",")).join("\n");
-  return headers + rows;
-};
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useBreweryContext } from "@/context/brewery-beer";
+import { useToast } from "@/context/toast";
+import {
+  buildBeerExportCsv,
+  createBeerCategoryCache,
+  buildBeerImportTemplateCsv,
+  createBeerForBrewery,
+  normalizeBeerImportRow,
+  parseBeerImportCsv,
+  resolveBeerCategoryIds,
+} from "@/lib/import/beerImport";
+import { Download, Loader2, Upload } from "lucide-react";
+import { useSession } from "next-auth/react";
+import React, { useRef, useState } from "react";
+import type {
+  BeerImportFailure,
+  BeerImportSummary,
+} from "@/lib/import/beerImport";
 
-const downloadCSVTemplate = (template) => {
-  const blob = new Blob([template], { type: "text/csv;charset=utf-8;" });
+const downloadCsv = (filename: string, csv: string) => {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
-  link.download = "beer_template.csv";
+  link.download = filename;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 };
 
 const FlatfilePortal = () => {
-  const { openPortal } = useFlatfile();
+  const { data: session } = useSession();
+  const { selectedBrewery, selectedBeers, mutateBeers, mutateBrewery, isAdmin } =
+    useBreweryContext();
+  const { addToast } = useToast();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [isImporting, setIsImporting] = useState(false);
+  const [summary, setSummary] = useState<BeerImportSummary | null>(null);
 
-  //  Validate and transform records via onRecordHook
-  const handleRecordValidation = (record: any) => {
-    // Transform malts and hops into arrays
-    const malts = record.get("malts");
-    if (malts) {
-      record.set(
-        "malts",
-        malts.split(",").map((malt: any) => malt.trim())
-      );
-    }
-
-    const hops = record.get("hops");
-    if (hops) {
-      record.set(
-        "hops",
-        hops.split(",").map((hop: any) => hop.trim())
-      );
-    }
-
-    // Convert ABV to a number
-    const abv = parseFloat(record.get("abv"));
-    record.set("abv", isNaN(abv) ? null : abv);
-
-    // Convert IBU to a number
-    const ibu = parseFloat(record.get("ibu"));
-    record.set("ibu", isNaN(ibu) ? null : ibu);
-
-    // Convert releaseDate to YYYY-MM-DD format using moment.js
-    const releaseDate = record.get("release_date");
-    if (releaseDate) {
-      const formattedDate = moment(releaseDate, [
-        "MM/DD/YYYY",
-        "M/D/YYYY",
-        "M/D/YY",
-        "YYYY-MM-DD",
-        "MMMM Do, YYYY",
-        "MMM D, YYYY",
-        "MMMM Do, YYYY",
-      ]).format("YYYY-MM-DD");
-      record.set("release_date", formattedDate);
-    }
-
-    // Convert archived to a boolean
-    const archived = record.get("archived");
-    record.set("archived", archived.toLowerCase() === "false");
-
-    return record;
-  };
-
-  const template = generateCSVTemplate(blueprint);
+  const accessToken = session?.user?.accessToken;
+  const breweryId = selectedBrewery?._id;
+  const canImport = Boolean(isAdmin && breweryId && accessToken);
 
   const handleDownloadTemplate = () => {
-    downloadCSVTemplate(template);
+    downloadCsv("beer_template.csv", buildBeerImportTemplateCsv());
+  };
+
+  const handleExport = () => {
+    downloadCsv(
+      `${selectedBrewery?.companyName || "beer"}-export.csv`,
+      buildBeerExportCsv(selectedBeers ?? [])
+    );
+  };
+
+  const pushFailure = (
+    failures: BeerImportFailure[],
+    failure: BeerImportFailure
+  ) => {
+    failures.push(failure);
+  };
+
+  const handleImportRows = async (csvText: string) => {
+    if (!selectedBrewery || !breweryId || !accessToken) {
+      throw new Error("Select a brewery and sign in before importing beers.");
+    }
+
+    const parsedRows = parseBeerImportCsv(csvText);
+    if (parsedRows.length === 0) {
+      throw new Error("No rows were found in the CSV file.");
+    }
+
+    const categoryCache = createBeerCategoryCache(selectedBrewery.categories);
+
+    const failures: BeerImportFailure[] = [];
+    let createdCount = 0;
+
+    for (let index = 0; index < parsedRows.length; index += 1) {
+      const rowNumber = index + 2;
+      const record = parsedRows[index];
+      const rowName =
+        record.Name || record.name || record["Beer Name"] || record["beer name"];
+
+      try {
+        const normalized = normalizeBeerImportRow(record);
+
+        if (!normalized.value) {
+          pushFailure(failures, {
+            rowNumber,
+            beerName: rowName || undefined,
+            message: normalized.errors.join(" "),
+          });
+          continue;
+        }
+
+        const categoryIds = await resolveBeerCategoryIds({
+          breweryId,
+          accessToken,
+          categoryCache,
+          categoryNames: normalized.value.category,
+        });
+
+        const createdBeer = await createBeerForBrewery({
+          breweryId,
+          accessToken,
+          beer: {
+            name: normalized.value.name,
+            style: normalized.value.style,
+            abv: normalized.value.abv ?? 0,
+            ibu: normalized.value.ibu ?? 0,
+            category: categoryIds,
+            malt: normalized.value.malt,
+            hops: normalized.value.hops,
+            description: normalized.value.description,
+            nameSake: normalized.value.nameSake,
+            notes: normalized.value.notes,
+            image: "",
+            archived: normalized.value.archived,
+            releasedOn: normalized.value.releasedOn,
+          },
+        });
+
+        if (!createdBeer?._id) {
+          pushFailure(failures, {
+            rowNumber,
+            beerName: normalized.value.name,
+            message: "Beer created but no record id was returned.",
+          });
+          continue;
+        }
+
+        createdCount += 1;
+      } catch (error) {
+        pushFailure(failures, {
+          rowNumber,
+          beerName: rowName || undefined,
+          message:
+            error instanceof Error ? error.message : "Failed to import row.",
+        });
+      }
+    }
+
+    if (createdCount > 0) {
+      await Promise.all([mutateBeers(), mutateBrewery()]);
+    }
+
+    const result: BeerImportSummary = {
+      createdCount,
+      failedCount: failures.length,
+      totalCount: parsedRows.length,
+      failures,
+    };
+
+    setSummary(result);
+
+    if (failures.length > 0) {
+      addToast(
+        `Imported ${createdCount} beer${createdCount === 1 ? "" : "s"} with ${failures.length} failure${
+          failures.length === 1 ? "" : "s"
+        }.`,
+        "info"
+      );
+    } else {
+      addToast(
+        `Imported ${createdCount} beer${createdCount === 1 ? "" : "s"} successfully.`,
+        "success"
+      );
+    }
+  };
+
+  const handleFileSelection = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+
+    if (!file) {
+      return;
+    }
+
+    setIsImporting(true);
+    try {
+      const csvText = await file.text();
+      await handleImportRows(csvText);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to import beers.";
+      setSummary({
+        createdCount: 0,
+        failedCount: 1,
+        totalCount: 0,
+        failures: [
+          {
+            rowNumber: 0,
+            message,
+          },
+        ],
+      });
+      addToast(message, "error");
+    } finally {
+      setIsImporting(false);
+    }
   };
 
   return (
     <>
-      <button className="btn btn-outline" onClick={openPortal}>
-        Upload Beers
-      </button>
-      <button className="btn btn-outline" onClick={handleDownloadTemplate}>
-        Download CSV Template
-      </button>
-      <Sheet
-        config={blueprint}
-        onSubmit={async ({ sheet }) => {
-          const data = await sheet.allData();
-          console.log("onSubmit", data);
-        }}
-        onRecordHook={(record) => handleRecordValidation(record)}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button type="button" variant="outline" onClick={handleDownloadTemplate}>
+          <Download className="mr-2 h-4 w-4" />
+          Template
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={!canImport || isImporting}
+        >
+          {isImporting ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Upload className="mr-2 h-4 w-4" />
+          )}
+          Import
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleExport}
+          disabled={!selectedBrewery}
+        >
+          <Download className="mr-2 h-4 w-4" />
+          Export
+        </Button>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".csv,text/csv"
+        className="hidden"
+        onChange={handleFileSelection}
       />
+
+      <Dialog
+        open={Boolean(summary)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSummary(null);
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Import summary</DialogTitle>
+            <DialogDescription>
+              Review the created beer count and any rows that need attention.
+            </DialogDescription>
+          </DialogHeader>
+
+          {summary && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-3 gap-3">
+                <div className="rounded-md border p-3">
+                  <p className="text-xs uppercase text-muted-foreground">
+                    Created
+                  </p>
+                  <p className="text-2xl font-semibold">
+                    {summary.createdCount}
+                  </p>
+                </div>
+                <div className="rounded-md border p-3">
+                  <p className="text-xs uppercase text-muted-foreground">
+                    Failed
+                  </p>
+                  <p className="text-2xl font-semibold">{summary.failedCount}</p>
+                </div>
+                <div className="rounded-md border p-3">
+                  <p className="text-xs uppercase text-muted-foreground">
+                    Total
+                  </p>
+                  <p className="text-2xl font-semibold">{summary.totalCount}</p>
+                </div>
+              </div>
+
+              {summary.failures.length > 0 ? (
+                <ScrollArea className="max-h-[18rem] rounded-md border">
+                  <div className="divide-y">
+                    {summary.failures.map((failure) => (
+                      <div
+                        key={`${failure.rowNumber}-${failure.message}`}
+                        className="space-y-1 p-3"
+                      >
+                        <p className="text-sm font-medium">
+                          Row {failure.rowNumber}
+                          {failure.beerName ? ` - ${failure.beerName}` : ""}
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          {failure.message}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </ScrollArea>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No row-level failures were reported.
+                </p>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </>
   );
 };
 
 export default FlatfilePortal;
-
-/* records
-: 
-Array(9)
-0
-: 
-{id: 'us_rc_bf9281d474904d2eaac55ae5a63d74d2', values: {…}, metadata: {…}, config: {…}, valid: false}
-1
-: 
-{id: 'us_rc_ff8585c6e50e4ff582f2337910d0d031', values: {…}, metadata: {…}, config: {…}, valid: false}
-2
-: 
-{id: 'us_rc_bf9e8bc3a04d4814bf64795ff4ba4a83', values: {…}, metadata: {…}, config: {…}, valid: false}
-3
-: 
-{id: 'us_rc_23fd47fb4dcb4b488809aa254a202f42', values: {…}, metadata: {…}, config: {…}, valid: false}
-4
-: 
-{id: 'us_rc_7507e1841b594acdafdb958071a9af6a', values: {…}, metadata: {…}, config: {…}, valid: false}
-5
-: 
-{id: 'us_rc_264bcd323d34434b937ba6dd9d09b829', values: {…}, metadata: {…}, config: {…}, valid: false}
-6
-: 
-{id: 'us_rc_f7a342235f7e4305a5e820c71ab8204c', values: {…}, metadata: {…}, config: {…}, valid: false}
-7
-: 
-{id: 'us_rc_eb29c3214f634709b040df529e4ecbec', values: {…}, metadata: {…}, config: {…}, valid: false}
-8
-: 
-{id: 'us_rc_d921fa0aed2d42ec8642bb53a9908fca', values: {…}, metadata: {…}, config: {…}, valid: false}
-length
-: 
-9
-[[Prototype]]
-: 
-Array(0)
-sheetId
-: 
-"us_sh_HnmAZL5Q"
-workbookId
-: 
-"us_wb_OkCqw1Pq" 
-*/

--- a/src/components/Settings/NotificationSettings.tsx
+++ b/src/components/Settings/NotificationSettings.tsx
@@ -1,160 +1,341 @@
 "use client";
+
 import updateUserNotifications from "@/lib/PUT/updateUserNotfications";
-import { Notifications } from "@/types/notifications";
+import { cn } from "@/lib/utils";
+import type { Notifications } from "@/types/notifications";
+import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useEffect, useRef, useState } from "react";
 
+type NotificationChannelKey = "newBeerRelease" | "beerUpdate";
+
+type NotificationSettingsState = {
+  allow: boolean;
+  newBeerRelease: {
+    email: boolean;
+    push: boolean;
+  };
+  beerUpdate: {
+    email: boolean;
+    push: boolean;
+  };
+};
+
+type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+const defaultNotifications: NotificationSettingsState = {
+  allow: true,
+  newBeerRelease: {
+    email: true,
+    push: true,
+  },
+  beerUpdate: {
+    email: true,
+    push: true,
+  },
+};
+
+const channelMeta: Record<
+  NotificationChannelKey,
+  { title: string; description: string }
+> = {
+  newBeerRelease: {
+    title: "New Beer Release",
+    description: "Get notified when a brewery publishes a new beer.",
+  },
+  beerUpdate: {
+    title: "Beer Updates",
+    description: "Get notified when a tracked beer changes.",
+  },
+};
+
+const notificationChannels = ["email", "push"] as const;
+
+const normalizeNotifications = (
+  notifications?: Partial<NotificationSettingsState> | null
+): NotificationSettingsState => ({
+  allow: notifications?.allow ?? defaultNotifications.allow,
+  newBeerRelease: {
+    email:
+      notifications?.newBeerRelease?.email ??
+      defaultNotifications.newBeerRelease.email,
+    push:
+      notifications?.newBeerRelease?.push ??
+      defaultNotifications.newBeerRelease.push,
+  },
+  beerUpdate: {
+    email:
+      notifications?.beerUpdate?.email ?? defaultNotifications.beerUpdate.email,
+    push:
+      notifications?.beerUpdate?.push ?? defaultNotifications.beerUpdate.push,
+  },
+});
+
+const isSameNotifications = (
+  left: NotificationSettingsState,
+  right: NotificationSettingsState
+) => JSON.stringify(left) === JSON.stringify(right);
+
 const NotificationSettings = () => {
   const { data: session, update } = useSession();
-  const [notifications, setNotification] = useState<Notifications>(
-    session?.user.notifications
+  const [notifications, setNotifications] = useState<NotificationSettingsState>(
+    () => normalizeNotifications(session?.user?.notifications as Notifications)
   );
-  const [hasChanges, setHasChanges] = useState(false); // To track if there are unsaved changes
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+  const [saveError, setSaveError] = useState("");
   const saveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isInitialRender = useRef(true);
-
-  // Get the keys from the notifications object
-  const [notificationKeys, setNotificationKeys] = useState<string[]>(() =>
-    session?.user?.notifications
-      ? Object.keys(session.user.notifications).filter(
-          (key) => key !== "allow" && key !== "_id"
-        )
-      : []
-  );
-
-  const saveChanges = async () => {
-    if (hasChanges) {
-      try {
-        // Call your updateUserNotifications function here
-        await updateUserNotifications({
-          notifications,
-          userId: session?.user.id,
-          accessToken: session?.user.accessToken,
-        });
-
-        await update({ updatedNotifications: notifications });
-        setHasChanges(false); // Reset the hasChanges flag after saving
-      } catch (error) {
-        console.error(error);
-        // Display error to the user or handle it accordingly
-      }
-    }
-  };
-  const debouncedSave = () => {
-    if (saveTimeout.current) {
-      clearTimeout(saveTimeout.current);
-    }
-    saveTimeout.current = setTimeout(saveChanges, 500);
-  };
+  const statusResetTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const saveRequestId = useRef(0);
+  const hasHydratedRef = useRef(false);
+  const lastSavedSnapshotRef = useRef("");
 
   useEffect(() => {
-    if (!notifications?.beerUpdate && !notifications?.newBeerRelease) {
-      setNotification((prev) => ({
-        ...prev,
-        allow: false,
-      }));
+    const nextNotifications = normalizeNotifications(
+      session?.user?.notifications as Notifications
+    );
+    const isFirstSync = !hasHydratedRef.current;
+
+    hasHydratedRef.current = true;
+    setNotifications((current) =>
+      isSameNotifications(current, nextNotifications) ? current : nextNotifications
+    );
+    lastSavedSnapshotRef.current = JSON.stringify(nextNotifications);
+
+    if (isFirstSync) {
+      setSaveStatus("idle");
+      setSaveError("");
     }
-  }, [notifications?.beerUpdate, notifications?.newBeerRelease]);
-
-  // Separate useEffect to set the hasChanges for autoSave
-  useEffect(() => {
-    setHasChanges(true); // Set the hasChanges flag when the notifications change
-  }, [notifications]);
+  }, [session?.user?.notifications]);
 
   useEffect(() => {
-    // If it's the initial render, just update the ref and return
-    if (isInitialRender.current) {
-      isInitialRender.current = false;
+    if (!hasHydratedRef.current) {
       return;
     }
 
-    debouncedSave();
+    const currentSnapshot = JSON.stringify(notifications);
+    if (currentSnapshot === lastSavedSnapshotRef.current) {
+      return;
+    }
 
-    // Cleanup function to run the save immediately if the component is unmounted
+    if (saveTimeout.current) {
+      clearTimeout(saveTimeout.current);
+    }
+    if (statusResetTimeout.current) {
+      clearTimeout(statusResetTimeout.current);
+    }
+
+    setSaveStatus("saving");
+    setSaveError("");
+
+    const requestId = ++saveRequestId.current;
+
+    saveTimeout.current = setTimeout(async () => {
+      try {
+        if (!session?.user?.id || !session?.user?.accessToken) {
+          throw new Error("Missing user session. Please sign in again.");
+        }
+
+        await updateUserNotifications({
+          notifications,
+          userId: session.user.id,
+          accessToken: session.user.accessToken,
+        });
+
+        if (requestId !== saveRequestId.current) {
+          return;
+        }
+
+        await update({ updatedNotifications: notifications });
+        lastSavedSnapshotRef.current = JSON.stringify(notifications);
+        setSaveStatus("saved");
+        setSaveError("");
+
+        statusResetTimeout.current = setTimeout(() => {
+          if (requestId === saveRequestId.current) {
+            setSaveStatus("idle");
+          }
+        }, 1800);
+      } catch (error) {
+        if (requestId !== saveRequestId.current) {
+          return;
+        }
+
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Unable to save notification preferences.";
+        setSaveStatus("error");
+        setSaveError(message);
+      }
+    }, 500);
+
     return () => {
       if (saveTimeout.current) {
         clearTimeout(saveTimeout.current);
       }
-      if (hasChanges) {
-        saveChanges();
+    };
+  }, [notifications, session?.user?.accessToken, session?.user?.id, update]);
+
+  useEffect(() => {
+    return () => {
+      if (saveTimeout.current) {
+        clearTimeout(saveTimeout.current);
+      }
+      if (statusResetTimeout.current) {
+        clearTimeout(statusResetTimeout.current);
       }
     };
-  }, [notifications]); // Only run this effect when notifications change
+  }, []);
 
-  if (!session?.user?.notifications) {
-    return <div>Loading...</div>;
+  if (
+    !session?.user?.notifications ||
+    !session?.user?.id ||
+    !session?.user?.accessToken
+  ) {
+    return (
+      <div className="py-6 text-sm text-base-content/70">
+        Loading notification preferences...
+      </div>
+    );
   }
 
   return (
-    notificationKeys && (
-      <div className="w-full ">
-        {/* <h3>Notification Preferences</h3> */}
-        <div className="flex flex-col w-full  ">
-          <div className=" flex items-center justify-between">
-            <h4>Allow All Notifications</h4>
-
-            <label className="cursor-pointer label w-fit">
-              <div className="label-text mr-1">
-                {notifications.allow ? "On" : "Off"}
-              </div>
-              <input
-                type="checkbox"
-                className="toggle toggle-accent"
-                onChange={(e) => {
-                  const checked = e.currentTarget.checked;
-                  setNotification((prev) => ({
-                    ...prev,
-                    allow: checked,
-                  }));
-                }}
-                checked={notifications?.allow}
-              />
-            </label>
+    <div className="w-full max-w-3xl space-y-6">
+      <div className="rounded-2xl border border-base-300 bg-base-100 p-6 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 className="text-xl font-semibold">Notification preferences</h3>
+            <p className="mt-1 text-sm text-base-content/70">
+              Control which beer updates you receive by email and push.
+            </p>
           </div>
-          <div className="w-11/12 mx-auto ">
-            {notifications.allow &&
-              notificationKeys.map((key) => (
-                <>
-                  <div
-                    key={key}
-                    className=" flex items-center justify-between "
-                  >
-                    <div className="label-text mr-1">
-                      {key === "newBeerRelease"
-                        ? "New Beer Release "
-                        : "Beer Updates"}
-                    </div>
-                    <label className="cursor-pointer label w-fit">
-                      <div
-                        className={`label-text mr-1 ${
-                          notifications[key].email ? "" : "text-opacity-50"
-                        }`}
-                      >
-                        {notifications[key].email ? "On" : "Off"}
+          <div
+            className={cn(
+              "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium",
+              saveStatus === "saving" && "bg-info/15 text-info",
+              saveStatus === "saved" && "bg-success/15 text-success",
+              saveStatus === "error" && "bg-error/15 text-error",
+              saveStatus === "idle" && "bg-base-200 text-base-content/70"
+            )}
+            aria-live="polite"
+          >
+            {saveStatus === "saving" && (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            )}
+            {saveStatus === "saved" && <CheckCircle2 className="h-3.5 w-3.5" />}
+            {saveStatus === "error" && <AlertCircle className="h-3.5 w-3.5" />}
+            <span>
+              {saveStatus === "saving" && "Saving changes"}
+              {saveStatus === "saved" && "Saved"}
+              {saveStatus === "error" && "Save failed"}
+              {saveStatus === "idle" && "All changes saved"}
+            </span>
+          </div>
+        </div>
+        {saveStatus === "error" && saveError ? (
+          <p className="mt-3 text-sm text-error">{saveError}</p>
+        ) : null}
+      </div>
+
+      <div className="rounded-2xl border border-base-300 bg-base-100 p-6 shadow-sm">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h4 className="text-base font-semibold">Allow notifications</h4>
+            <p className="mt-1 text-sm text-base-content/70">
+              Master switch for all notification delivery.
+            </p>
+          </div>
+          <label className="label cursor-pointer gap-3 p-0">
+            <span className="label-text text-sm font-medium">
+              {notifications.allow ? "On" : "Off"}
+            </span>
+            <input
+              type="checkbox"
+              className="toggle toggle-accent"
+              onChange={(e) => {
+                const checked = e.currentTarget.checked;
+                setNotifications((prev) => ({
+                  ...prev,
+                  allow: checked,
+                }));
+              }}
+              checked={notifications.allow}
+              aria-label="Allow notifications"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          "space-y-4 transition-opacity",
+          notifications.allow ? "opacity-100" : "opacity-60"
+        )}
+      >
+        {(Object.keys(channelMeta) as NotificationChannelKey[]).map((key) => (
+          <div
+            key={key}
+            className="rounded-2xl border border-base-300 bg-base-100 p-5 shadow-sm"
+          >
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="max-w-md">
+                <h5 className="text-base font-semibold">{channelMeta[key].title}</h5>
+                <p className="mt-1 text-sm text-base-content/70">
+                  {channelMeta[key].description}
+                </p>
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {notificationChannels.map((channel) => {
+                  const checked = notifications[key][channel];
+                  return (
+                    <label
+                      key={`${key}-${channel}`}
+                      className="flex min-w-36 items-center justify-between gap-3 rounded-xl border border-base-300 px-4 py-3"
+                    >
+                      <div>
+                        <div className="text-sm font-medium capitalize">
+                          {channel}
+                        </div>
+                        <div className="text-xs text-base-content/60">
+                          {notifications.allow
+                            ? "Stored preference"
+                            : "Disabled until notifications are enabled"}
+                        </div>
                       </div>
                       <input
                         type="checkbox"
-                        className="toggle toggle-accent bg-[#252525]"
+                        className="toggle toggle-accent"
                         onChange={(e) => {
-                          const checked = e.currentTarget.checked;
-                          setNotification((prev) => ({
+                          const nextChecked = e.currentTarget.checked;
+                          setNotifications((prev) => ({
                             ...prev,
                             [key]: {
                               ...prev[key],
-                              email: checked, // toggles the email property
+                              [channel]: nextChecked,
                             },
                           }));
                         }}
-                        checked={notifications[key].email}
+                        checked={checked}
+                        disabled={!notifications.allow || saveStatus === "saving"}
+                        aria-label={`${channel} notifications for ${channelMeta[key].title}`}
                       />
                     </label>
-                  </div>
-                </>
-              ))}
+                  );
+                })}
+              </div>
+            </div>
           </div>
-        </div>
+        ))}
       </div>
-    )
+
+      {!notifications.allow ? (
+        <p className="text-sm text-base-content/70">
+          Notification channels stay visible but disabled while notifications are
+          off. Turn them back on to edit email and push delivery preferences.
+        </p>
+      ) : null}
+    </div>
   );
 };
 

--- a/src/components/beers/beer-form.tsx
+++ b/src/components/beers/beer-form.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { FileUploader } from "@/components/file-uploader";
-import { MultiSelect } from "@/components/selects/multi-select";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -26,20 +24,16 @@ import { updateImage } from "@/lib/supabase/updateImage";
 import { Beer, NewBeer } from "@/types/beer";
 import BeerFormSchema from "@/zod/beer-schema";
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Beer as BeerIcon,
-  Hop,
-  LayoutGrid,
-  Percent,
-  Tag,
-  Wheat,
-} from "lucide-react";
+import { Beer as BeerIcon, Hop, LayoutGrid, Percent, Tag, Wheat } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import * as z from "zod";
+import { FileUploader } from "@/components/file-uploader";
+import { MultiSelect } from "@/components/selects/multi-select";
+import BeerPostCreateShare from "./beer-post-create-share";
 
 type BeerSchemaValues = z.infer<typeof BeerFormSchema>;
 
@@ -51,8 +45,10 @@ export default function BeerForm({
   pageTitle: string;
 }) {
   const router = useRouter();
-  const { data: session, status, update } = useSession();
+  const { data: session } = useSession();
   const { selectedBrewery, mutateBeers, mutateBrewery } = useBreweryContext();
+  const isCreateMode = !initialData?._id;
+  const [createdBeer, setCreatedBeer] = useState<Beer | null>(null);
   const [beerImage, setBeerImage] = useState<File | string | null>(
     initialData?.image || null
   );
@@ -79,6 +75,14 @@ export default function BeerForm({
     resolver: zodResolver(BeerFormSchema),
     defaultValues: defaultValues,
   });
+
+  useEffect(() => {
+    if (!createdBeer) {
+      return;
+    }
+
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [createdBeer]);
 
   async function onSubmit(values: BeerSchemaValues) {
     try {
@@ -111,7 +115,13 @@ export default function BeerForm({
         toast.success(
           `${beerRes.name} successfully ${initialData?._id ? "edited" : "created"}!`
         );
-        router.push(`/dashboard/breweries/${selectedBrewery._id}/beers`);
+        if (initialData?._id) {
+          router.push(`/dashboard/breweries/${selectedBrewery._id}/beers`);
+        } else {
+          setCreatedBeer(beerRes);
+          form.reset(defaultValues);
+          setBeerImage(null);
+        }
       }
     } catch (err: string | any) {
       console.error(err);
@@ -126,6 +136,20 @@ export default function BeerForm({
         </CardTitle>
       </CardHeader>
       <CardContent>
+        {isCreateMode && createdBeer && selectedBrewery?._id && (
+          <div className="mb-8">
+            <BeerPostCreateShare
+              beer={createdBeer}
+              sharePath={`/dashboard/breweries/${selectedBrewery._id}/beers/${createdBeer._id}`}
+              onCreateAnother={() => {
+                setCreatedBeer(null);
+                form.reset(defaultValues);
+                setBeerImage(null);
+                window.scrollTo({ top: 0, behavior: "smooth" });
+              }}
+            />
+          </div>
+        )}
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(onSubmit, onFormError)}

--- a/src/components/beers/beer-post-create-share.tsx
+++ b/src/components/beers/beer-post-create-share.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { Beer } from "@/types/beer";
+import { Check, Copy, ExternalLink, Share2 } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+type BeerPostCreateShareProps = {
+  beer: Pick<Beer, "_id" | "name">;
+  sharePath: string;
+  onCreateAnother?: () => void;
+  className?: string;
+};
+
+export default function BeerPostCreateShare({
+  beer,
+  sharePath,
+  onCreateAnother,
+  className,
+}: BeerPostCreateShareProps) {
+  const [shareUrl, setShareUrl] = useState("");
+  const [status, setStatus] = useState<"idle" | "copied" | "shared" | "error">(
+    "idle"
+  );
+
+  useEffect(() => {
+    if (!sharePath) {
+      setShareUrl("");
+      return;
+    }
+
+    setShareUrl(new URL(sharePath, window.location.origin).toString());
+  }, [sharePath]);
+
+  const canShare = useMemo(() => {
+    return typeof navigator !== "undefined" && typeof navigator.share === "function";
+  }, []);
+
+  const copyLink = async () => {
+    if (!shareUrl || !navigator?.clipboard?.writeText) {
+      setStatus("error");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setStatus("copied");
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  const shareLink = async () => {
+    if (!shareUrl || typeof navigator === "undefined" || !navigator.share) {
+      return copyLink();
+    }
+
+    try {
+      await navigator.share({
+        title: beer.name,
+        text: `Check out ${beer.name}`,
+        url: shareUrl,
+      });
+      setStatus("shared");
+    } catch {
+      // The user may cancel the share sheet. Keep the UI quiet in that case.
+    }
+  };
+
+  if (!sharePath) {
+    return null;
+  }
+
+  return (
+    <Card className={cn("border-dashed bg-muted/30", className)}>
+      <CardHeader className="space-y-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Share2 className="h-4 w-4" />
+          Beer created
+        </CardTitle>
+        <CardDescription>
+          Share <span className="font-medium text-foreground">{beer.name}</span>
+          with your team or open the detail page.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="outline" onClick={copyLink}>
+            {status === "copied" ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            {status === "copied" ? "Copied" : "Copy link"}
+          </Button>
+          {canShare && (
+            <Button type="button" variant="secondary" onClick={shareLink}>
+              <Share2 className="h-4 w-4" />
+              Share
+            </Button>
+          )}
+          <Button asChild type="button" variant="default">
+            <Link href={sharePath}>
+              <ExternalLink className="h-4 w-4" />
+              View beer
+            </Link>
+          </Button>
+          {onCreateAnother && (
+            <Button type="button" variant="ghost" onClick={onCreateAnother}>
+              Create another
+            </Button>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {status === "copied" && "Beer link copied to your clipboard."}
+          {status === "shared" && "Share sheet opened successfully."}
+          {status === "error" &&
+            "Unable to copy the link. Use View beer to open the beer page."}
+          {status === "idle" && shareUrl}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/beers/beer-table-actions/beer-table-container.tsx
+++ b/src/components/beers/beer-table-actions/beer-table-container.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import TableViewToggleButton from "@/components/Buttons/table-view-toggle-btn";
-import BeerCardSkeleton from "@/components/skeletons/beer-card-skeleton";
 import { DataTableFilterBox } from "@/components/ui/table/data-table-filter-box";
 import { DataTableResetFilter } from "@/components/ui/table/data-table-reset-filter";
 import { DataTableSearch } from "@/components/ui/table/data-table-search";
-import { DataTableSkeleton } from "@/components/ui/table/data-table-skeleton";
+import FlatfilePortal from "@/components/FlatfilePortal/FlatfilePortal";
 import { useBreweryContext } from "@/context/brewery-beer";
-import { useIsMobile } from "@/hooks/use-mobile";
 import { useSearchParams } from "next/navigation";
-import { Suspense, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import BeerListCarousel from "../beer-list-carousel";
 import { BeerListTable } from "../beer-list-table";
 import { columns } from "./columns";
@@ -28,7 +25,6 @@ export default function BeerTableContainer() {
     setPage,
     setSearchQuery,
   } = useProductTableFilters();
-  const isMobile = useIsMobile();
   const searchParams = useSearchParams();
   const { selectedBeers, selectedBrewery, isAdmin } = useBreweryContext();
 
@@ -146,6 +142,7 @@ export default function BeerTableContainer() {
             isFilterActive={isAnyFilterActive}
             onReset={resetFilters}
           />
+          {isAdmin && <FlatfilePortal />}
         </>
       }
       tableComponent={

--- a/src/features/overview/components/area-graph.tsx
+++ b/src/features/overview/components/area-graph.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useMemo } from "react";
 import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
+import { BarChart3 } from "lucide-react";
 
+import { useBreweryContext } from "@/context/brewery-beer";
 import {
   Card,
   CardContent,
@@ -16,39 +19,76 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { TrendingUp } from "lucide-react";
-
-const chartData = [
-  { month: "January", desktop: 186, mobile: 80 },
-  { month: "February", desktop: 305, mobile: 200 },
-  { month: "March", desktop: 237, mobile: 120 },
-  { month: "April", desktop: 73, mobile: 190 },
-  { month: "May", desktop: 209, mobile: 130 },
-  { month: "June", desktop: 214, mobile: 140 },
-];
+import { Skeleton } from "@/components/ui/skeleton";
+import { buildMonthlyBeerData } from "../lib/overview-data";
 
 const chartConfig = {
-  visitors: {
-    label: "Visitors",
-  },
-  desktop: {
-    label: "Desktop",
-    color: "var(--primary)",
-  },
-  mobile: {
-    label: "Mobile",
+  beers: {
+    label: "Beers added",
     color: "var(--primary)",
   },
 } satisfies ChartConfig;
 
-export function AreaGraph() {
+function EmptyStateCard({ title, description }: { title: string; description: string }) {
   return (
     <Card className="@container/card">
       <CardHeader>
-        <CardTitle>Area Chart - Stacked</CardTitle>
-        <CardDescription>
-          Showing total visitors for the last 6 months
-        </CardDescription>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex min-h-[220px] items-center justify-center">
+        <div className="text-muted-foreground flex flex-col items-center gap-2 text-sm">
+          <BarChart3 className="size-5" />
+          <span>No timeline data yet</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function AreaGraph() {
+  const { selectedBrewery, selectedBeers, breweryLoading, beersLoading } =
+    useBreweryContext();
+
+  const chartData = useMemo(() => buildMonthlyBeerData(selectedBeers), [selectedBeers]);
+
+  if (breweryLoading || beersLoading) {
+    return (
+      <Card className="@container/card">
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-56" />
+        </CardHeader>
+        <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
+          <Skeleton className="h-[250px] w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!selectedBrewery) {
+    return (
+      <EmptyStateCard
+        title="Beer additions over time"
+        description="Select a brewery to see monthly beer creation volume."
+      />
+    );
+  }
+
+  if (!selectedBeers?.length) {
+    return (
+      <EmptyStateCard
+        title="Beer additions over time"
+        description="This brewery has not added any beers yet."
+      />
+    );
+  }
+
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle>Beer additions over time</CardTitle>
+        <CardDescription>New beers added across the last six months</CardDescription>
       </CardHeader>
       <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
         <ChartContainer
@@ -63,28 +103,16 @@ export function AreaGraph() {
             }}
           >
             <defs>
-              <linearGradient id="fillDesktop" x1="0" y1="0" x2="0" y2="1">
+              <linearGradient id="fillBeers" x1="0" y1="0" x2="0" y2="1">
                 <stop
                   offset="5%"
-                  stopColor="var(--color-desktop)"
-                  stopOpacity={1.0}
+                  stopColor="var(--color-beers)"
+                  stopOpacity={0.9}
                 />
                 <stop
                   offset="95%"
-                  stopColor="var(--color-desktop)"
-                  stopOpacity={0.1}
-                />
-              </linearGradient>
-              <linearGradient id="fillMobile" x1="0" y1="0" x2="0" y2="1">
-                <stop
-                  offset="5%"
-                  stopColor="var(--color-mobile)"
-                  stopOpacity={0.8}
-                />
-                <stop
-                  offset="95%"
-                  stopColor="var(--color-mobile)"
-                  stopOpacity={0.1}
+                  stopColor="var(--color-beers)"
+                  stopOpacity={0.05}
                 />
               </linearGradient>
             </defs>
@@ -95,39 +123,23 @@ export function AreaGraph() {
               axisLine={false}
               tickMargin={8}
               minTickGap={32}
-              tickFormatter={(value) => value.slice(0, 3)}
             />
             <ChartTooltip
               cursor={false}
               content={<ChartTooltipContent indicator="dot" />}
             />
             <Area
-              dataKey="mobile"
+              dataKey="beers"
               type="natural"
-              fill="url(#fillMobile)"
-              stroke="var(--color-mobile)"
-              stackId="a"
-            />
-            <Area
-              dataKey="desktop"
-              type="natural"
-              fill="url(#fillDesktop)"
-              stroke="var(--color-desktop)"
-              stackId="a"
+              fill="url(#fillBeers)"
+              stroke="var(--color-beers)"
             />
           </AreaChart>
         </ChartContainer>
       </CardContent>
       <CardFooter>
-        <div className="flex w-full items-start gap-2 text-sm">
-          <div className="grid gap-2">
-            <div className="flex items-center gap-2 leading-none font-medium">
-              Trending up by 5.2% this month <TrendingUp className="h-4 w-4" />
-            </div>
-            <div className="text-muted-foreground flex items-center gap-2 leading-none">
-              January - June 2024
-            </div>
-          </div>
+        <div className="text-muted-foreground text-sm">
+          Counts are based on beer record creation dates.
         </div>
       </CardFooter>
     </Card>

--- a/src/features/overview/components/bar-graph.tsx
+++ b/src/features/overview/components/bar-graph.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import * as React from "react";
+import { useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+import { BarChart3 } from "lucide-react";
 
+import { useBreweryContext } from "@/context/brewery-beer";
 import {
   Card,
   CardContent,
@@ -16,182 +18,81 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-
-export const description = "An interactive bar chart";
-
-const chartData = [
-  { date: "2024-04-01", desktop: 222, mobile: 150 },
-  { date: "2024-04-02", desktop: 97, mobile: 180 },
-  { date: "2024-04-03", desktop: 167, mobile: 120 },
-  { date: "2024-04-04", desktop: 242, mobile: 260 },
-  { date: "2024-04-05", desktop: 373, mobile: 290 },
-  { date: "2024-04-06", desktop: 301, mobile: 340 },
-  { date: "2024-04-07", desktop: 245, mobile: 180 },
-  { date: "2024-04-08", desktop: 409, mobile: 320 },
-  { date: "2024-04-09", desktop: 59, mobile: 110 },
-  { date: "2024-04-10", desktop: 261, mobile: 190 },
-  { date: "2024-04-11", desktop: 327, mobile: 350 },
-  { date: "2024-04-12", desktop: 292, mobile: 210 },
-  { date: "2024-04-13", desktop: 342, mobile: 380 },
-  { date: "2024-04-14", desktop: 137, mobile: 220 },
-  { date: "2024-04-15", desktop: 120, mobile: 170 },
-  { date: "2024-04-16", desktop: 138, mobile: 190 },
-  { date: "2024-04-17", desktop: 446, mobile: 360 },
-  { date: "2024-04-18", desktop: 364, mobile: 410 },
-  { date: "2024-04-19", desktop: 243, mobile: 180 },
-  { date: "2024-04-20", desktop: 89, mobile: 150 },
-  { date: "2024-04-21", desktop: 137, mobile: 200 },
-  { date: "2024-04-22", desktop: 224, mobile: 170 },
-  { date: "2024-04-23", desktop: 138, mobile: 230 },
-  { date: "2024-04-24", desktop: 387, mobile: 290 },
-  { date: "2024-04-25", desktop: 215, mobile: 250 },
-  { date: "2024-04-26", desktop: 75, mobile: 130 },
-  { date: "2024-04-27", desktop: 383, mobile: 420 },
-  { date: "2024-04-28", desktop: 122, mobile: 180 },
-  { date: "2024-04-29", desktop: 315, mobile: 240 },
-  { date: "2024-04-30", desktop: 454, mobile: 380 },
-  { date: "2024-05-01", desktop: 165, mobile: 220 },
-  { date: "2024-05-02", desktop: 293, mobile: 310 },
-  { date: "2024-05-03", desktop: 247, mobile: 190 },
-  { date: "2024-05-04", desktop: 385, mobile: 420 },
-  { date: "2024-05-05", desktop: 481, mobile: 390 },
-  { date: "2024-05-06", desktop: 498, mobile: 520 },
-  { date: "2024-05-07", desktop: 388, mobile: 300 },
-  { date: "2024-05-08", desktop: 149, mobile: 210 },
-  { date: "2024-05-09", desktop: 227, mobile: 180 },
-  { date: "2024-05-10", desktop: 293, mobile: 330 },
-  { date: "2024-05-11", desktop: 335, mobile: 270 },
-  { date: "2024-05-12", desktop: 197, mobile: 240 },
-  { date: "2024-05-13", desktop: 197, mobile: 160 },
-  { date: "2024-05-14", desktop: 448, mobile: 490 },
-  { date: "2024-05-15", desktop: 473, mobile: 380 },
-  { date: "2024-05-16", desktop: 338, mobile: 400 },
-  { date: "2024-05-17", desktop: 499, mobile: 420 },
-  { date: "2024-05-18", desktop: 315, mobile: 350 },
-  { date: "2024-05-19", desktop: 235, mobile: 180 },
-  { date: "2024-05-20", desktop: 177, mobile: 230 },
-  { date: "2024-05-21", desktop: 82, mobile: 140 },
-  { date: "2024-05-22", desktop: 81, mobile: 120 },
-  { date: "2024-05-23", desktop: 252, mobile: 290 },
-  { date: "2024-05-24", desktop: 294, mobile: 220 },
-  { date: "2024-05-25", desktop: 201, mobile: 250 },
-  { date: "2024-05-26", desktop: 213, mobile: 170 },
-  { date: "2024-05-27", desktop: 420, mobile: 460 },
-  { date: "2024-05-28", desktop: 233, mobile: 190 },
-  { date: "2024-05-29", desktop: 78, mobile: 130 },
-  { date: "2024-05-30", desktop: 340, mobile: 280 },
-  { date: "2024-05-31", desktop: 178, mobile: 230 },
-  { date: "2024-06-01", desktop: 178, mobile: 200 },
-  { date: "2024-06-02", desktop: 470, mobile: 410 },
-  { date: "2024-06-03", desktop: 103, mobile: 160 },
-  { date: "2024-06-04", desktop: 439, mobile: 380 },
-  { date: "2024-06-05", desktop: 88, mobile: 140 },
-  { date: "2024-06-06", desktop: 294, mobile: 250 },
-  { date: "2024-06-07", desktop: 323, mobile: 370 },
-  { date: "2024-06-08", desktop: 385, mobile: 320 },
-  { date: "2024-06-09", desktop: 438, mobile: 480 },
-  { date: "2024-06-10", desktop: 155, mobile: 200 },
-  { date: "2024-06-11", desktop: 92, mobile: 150 },
-  { date: "2024-06-12", desktop: 492, mobile: 420 },
-  { date: "2024-06-13", desktop: 81, mobile: 130 },
-  { date: "2024-06-14", desktop: 426, mobile: 380 },
-  { date: "2024-06-15", desktop: 307, mobile: 350 },
-  { date: "2024-06-16", desktop: 371, mobile: 310 },
-  { date: "2024-06-17", desktop: 475, mobile: 520 },
-  { date: "2024-06-18", desktop: 107, mobile: 170 },
-  { date: "2024-06-19", desktop: 341, mobile: 290 },
-  { date: "2024-06-20", desktop: 408, mobile: 450 },
-  { date: "2024-06-21", desktop: 169, mobile: 210 },
-  { date: "2024-06-22", desktop: 317, mobile: 270 },
-  { date: "2024-06-23", desktop: 480, mobile: 530 },
-  { date: "2024-06-24", desktop: 132, mobile: 180 },
-  { date: "2024-06-25", desktop: 141, mobile: 190 },
-  { date: "2024-06-26", desktop: 434, mobile: 380 },
-  { date: "2024-06-27", desktop: 448, mobile: 490 },
-  { date: "2024-06-28", desktop: 149, mobile: 200 },
-  { date: "2024-06-29", desktop: 103, mobile: 160 },
-  { date: "2024-06-30", desktop: 446, mobile: 400 },
-];
+import { Skeleton } from "@/components/ui/skeleton";
+import { buildCategoryBarData } from "../lib/overview-data";
 
 const chartConfig = {
-  views: {
-    label: "Page Views",
-  },
-  desktop: {
-    label: "Desktop",
-    color: "var(--primary)",
-  },
-  mobile: {
-    label: "Mobile",
-    color: "var(--primary)",
-  },
-  error: {
-    label: "Error",
+  beers: {
+    label: "Beers",
     color: "var(--primary)",
   },
 } satisfies ChartConfig;
 
-export function BarGraph() {
-  const [activeChart, setActiveChart] =
-    React.useState<keyof typeof chartConfig>("desktop");
+function EmptyStateCard({ title, description }: { title: string; description: string }) {
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex min-h-[220px] items-center justify-center">
+        <div className="text-muted-foreground flex flex-col items-center gap-2 text-sm">
+          <BarChart3 className="size-5" />
+          <span>Nothing to chart yet</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
-  const total = React.useMemo(
-    () => ({
-      desktop: chartData.reduce((acc, curr) => acc + curr.desktop, 0),
-      mobile: chartData.reduce((acc, curr) => acc + curr.mobile, 0),
-    }),
-    []
+export function BarGraph() {
+  const { selectedBrewery, selectedBeers, breweryLoading, beersLoading } =
+    useBreweryContext();
+
+  const chartData = useMemo(
+    () => buildCategoryBarData(selectedBrewery, selectedBeers),
+    [selectedBrewery, selectedBeers]
   );
 
-  const [isClient, setIsClient] = React.useState(false);
+  if (breweryLoading || beersLoading) {
+    return (
+      <Card className="@container/card">
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-56" />
+        </CardHeader>
+        <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
+          <Skeleton className="h-[250px] w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
 
-  React.useEffect(() => {
-    setIsClient(true);
-  }, []);
+  if (!selectedBrewery) {
+    return (
+      <EmptyStateCard
+        title="Beers by category"
+        description="Select a brewery to see how its beers are distributed across categories."
+      />
+    );
+  }
 
-  React.useEffect(() => {
-    if (activeChart === "error") {
-      throw new Error("Mocking Error");
-    }
-  }, [activeChart]);
-
-  if (!isClient) {
-    return null;
+  if (!chartData.length) {
+    return (
+      <EmptyStateCard
+        title="Beers by category"
+        description="This brewery has no categorized beers yet."
+      />
+    );
   }
 
   return (
-    <Card className="@container/card !pt-3">
-      <CardHeader className="flex flex-col items-stretch space-y-0 border-b !p-0 sm:flex-row">
-        <div className="flex flex-1 flex-col justify-center gap-1 px-6 !py-0">
-          <CardTitle>Bar Chart - Interactive</CardTitle>
-          <CardDescription>
-            <span className="hidden @[540px]/card:block">
-              Total for the last 3 months
-            </span>
-            <span className="@[540px]/card:hidden">Last 3 months</span>
-          </CardDescription>
-        </div>
-        <div className="flex">
-          {["desktop", "mobile", "error"].map((key) => {
-            const chart = key as keyof typeof chartConfig;
-            if (!chart || total[key as keyof typeof total] === 0) return null;
-            return (
-              <button
-                key={chart}
-                data-active={activeChart === chart}
-                className="data-[active=true]:bg-primary/5 hover:bg-primary/5 relative flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left transition-colors duration-200 even:border-l sm:border-t-0 sm:border-l sm:px-8 sm:py-6"
-                onClick={() => setActiveChart(chart)}
-              >
-                <span className="text-muted-foreground text-xs">
-                  {chartConfig[chart].label}
-                </span>
-                <span className="text-lg leading-none font-bold sm:text-3xl">
-                  {total[key as keyof typeof total]?.toLocaleString()}
-                </span>
-              </button>
-            );
-          })}
-        </div>
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle>Beers by category</CardTitle>
+        <CardDescription>
+          Counted from the selected brewery&apos;s current beer catalog
+        </CardDescription>
       </CardHeader>
       <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
         <ChartContainer
@@ -205,56 +106,25 @@ export function BarGraph() {
               right: 12,
             }}
           >
-            <defs>
-              <linearGradient id="fillBar" x1="0" y1="0" x2="0" y2="1">
-                <stop
-                  offset="0%"
-                  stopColor="var(--primary)"
-                  stopOpacity={0.8}
-                />
-                <stop
-                  offset="100%"
-                  stopColor="var(--primary)"
-                  stopOpacity={0.2}
-                />
-              </linearGradient>
-            </defs>
             <CartesianGrid vertical={false} />
             <XAxis
-              dataKey="date"
+              dataKey="category"
               tickLine={false}
               axisLine={false}
               tickMargin={8}
-              minTickGap={32}
-              tickFormatter={(value) => {
-                const date = new Date(value);
-                return date.toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                });
-              }}
+              minTickGap={24}
             />
             <ChartTooltip
               cursor={{ fill: "var(--primary)", opacity: 0.1 }}
               content={
                 <ChartTooltipContent
-                  className="w-[150px]"
-                  nameKey="views"
-                  labelFormatter={(value) => {
-                    return new Date(value).toLocaleDateString("en-US", {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                    });
-                  }}
+                  className="w-[180px]"
+                  nameKey="beers"
+                  labelFormatter={(value) => value}
                 />
               }
             />
-            <Bar
-              dataKey={activeChart}
-              fill="url(#fillBar)"
-              radius={[4, 4, 0, 0]}
-            />
+            <Bar dataKey="beers" fill="var(--primary)" radius={[4, 4, 0, 0]} />
           </BarChart>
         </ChartContainer>
       </CardContent>

--- a/src/features/overview/components/overview.tsx
+++ b/src/features/overview/components/overview.tsx
@@ -1,5 +1,10 @@
-import PageContainer from "@/components/layout/page-container";
-import { Button } from "@/components/ui/button";
+"use client";
+
+import type { ReactNode } from "react";
+import { useMemo } from "react";
+import { Beer, Layers3, Percent } from "lucide-react";
+
+import { useBreweryContext } from "@/context/brewery-beer";
 import {
   Card,
   CardContent,
@@ -7,160 +12,118 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { AreaGraph } from "./area-graph";
-import { BarGraph } from "./bar-graph";
-import { PieGraph } from "./pie-graph";
-import { RecentSales } from "./recent-sales";
+import { Skeleton } from "@/components/ui/skeleton";
+import { getOverviewContextState } from "../lib/overview-data";
 
-export default function OverViewPage() {
+function OverviewMetricCard({
+  label,
+  value,
+  description,
+  icon,
+}: {
+  label: string;
+  value: string;
+  description: string;
+  icon: ReactNode;
+}) {
   return (
-    <PageContainer>
-      <div className="flex flex-1 flex-col space-y-2">
-        <div className="flex items-center justify-between space-y-2">
-          <h2 className="text-2xl font-bold tracking-tight">
-            Hi, Welcome back 👋
-          </h2>
-          <div className="hidden items-center space-x-2 md:flex">
-            <Button>Download</Button>
-          </div>
+    <Card className="@container/card">
+      <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+        <div className="space-y-1">
+          <CardDescription>{label}</CardDescription>
+          <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
+            {value}
+          </CardTitle>
         </div>
-        <Tabs defaultValue="overview" className="space-y-4">
-          <TabsList>
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="analytics" disabled>
-              Analytics
-            </TabsTrigger>
-          </TabsList>
-          <TabsContent value="overview" className="space-y-4">
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    Total Revenue
-                  </CardTitle>
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    className="h-4 w-4 text-muted-foreground"
-                  >
-                    <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
-                  </svg>
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">$45,231.89</div>
-                  <p className="text-xs text-muted-foreground">
-                    +20.1% from last month
-                  </p>
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    Subscriptions
-                  </CardTitle>
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    className="h-4 w-4 text-muted-foreground"
-                  >
-                    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-                    <circle cx="9" cy="7" r="4" />
-                    <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
-                  </svg>
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">+2350</div>
-                  <p className="text-xs text-muted-foreground">
-                    +180.1% from last month
-                  </p>
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">Sales</CardTitle>
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    className="h-4 w-4 text-muted-foreground"
-                  >
-                    <rect width="20" height="14" x="2" y="5" rx="2" />
-                    <path d="M2 10h20" />
-                  </svg>
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">+12,234</div>
-                  <p className="text-xs text-muted-foreground">
-                    +19% from last month
-                  </p>
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    Active Now
-                  </CardTitle>
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    className="h-4 w-4 text-muted-foreground"
-                  >
-                    <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
-                  </svg>
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">+573</div>
-                  <p className="text-xs text-muted-foreground">
-                    +201 since last hour
-                  </p>
-                </CardContent>
-              </Card>
-            </div>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-7">
-              <div className="col-span-4">
-                <BarGraph />
-              </div>
-              <Card className="col-span-4 md:col-span-3">
-                <CardHeader>
-                  <CardTitle>Recent Sales</CardTitle>
-                  <CardDescription>
-                    You made 265 sales this month.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <RecentSales />
-                </CardContent>
-              </Card>
-              <div className="col-span-4">
-                <AreaGraph />
-              </div>
-              <div className="col-span-4 md:col-span-3">
-                <PieGraph />
-              </div>
-            </div>
-          </TabsContent>
-        </Tabs>
+        <div className="text-muted-foreground rounded-lg border border-border/60 bg-muted/30 p-2">
+          {icon}
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <p className="text-muted-foreground text-sm">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function OverviewMetricSkeleton() {
+  return (
+    <Card className="@container/card">
+      <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-8 w-20" />
+        </div>
+        <Skeleton className="h-10 w-10 rounded-lg" />
+      </CardHeader>
+      <CardContent className="pt-0">
+        <Skeleton className="h-4 w-full" />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function OverviewSummary() {
+  const { selectedBrewery, selectedBeers, breweryLoading, beersLoading } =
+    useBreweryContext();
+
+  const overview = useMemo(
+    () => getOverviewContextState(selectedBrewery, selectedBeers),
+    [selectedBrewery, selectedBeers]
+  );
+
+  if (breweryLoading || beersLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <OverviewMetricSkeleton key={index} />
+        ))}
       </div>
-    </PageContainer>
+    );
+  }
+
+  if (!overview.hasBrewery) {
+    return (
+      <Card className="border-dashed">
+        <CardHeader>
+          <CardTitle>Select a brewery</CardTitle>
+          <CardDescription>
+            Pick a brewery from the switcher to see live counts for beers,
+            categories, and ABV.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const metrics = overview.metrics;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <OverviewMetricCard
+        label={metrics[0].label}
+        value={metrics[0].value}
+        description={metrics[0].description}
+        icon={<Beer className="size-4" />}
+      />
+      <OverviewMetricCard
+        label={metrics[1].label}
+        value={metrics[1].value}
+        description={metrics[1].description}
+        icon={<Beer className="size-4" />}
+      />
+      <OverviewMetricCard
+        label={metrics[2].label}
+        value={metrics[2].value}
+        description={metrics[2].description}
+        icon={<Layers3 className="size-4" />}
+      />
+      <OverviewMetricCard
+        label={metrics[3].label}
+        value={metrics[3].value}
+        description={metrics[3].description}
+        icon={<Percent className="size-4" />}
+      />
+    </div>
   );
 }

--- a/src/features/overview/components/pie-graph.tsx
+++ b/src/features/overview/components/pie-graph.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import * as React from "react";
-
+import { useMemo } from "react";
 import { Label, Pie, PieChart } from "recharts";
+import { Users } from "lucide-react";
 
+import { useBreweryContext } from "@/context/brewery-beer";
 import {
   Card,
   CardContent,
@@ -18,56 +19,88 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { TrendingUp } from "lucide-react";
-
-const chartData = [
-  { browser: "chrome", visitors: 275, fill: "var(--primary)" },
-  { browser: "safari", visitors: 200, fill: "var(--primary-light)" },
-  { browser: "firefox", visitors: 287, fill: "var(--primary-lighter)" },
-  { browser: "edge", visitors: 173, fill: "var(--primary-dark)" },
-  { browser: "other", visitors: 190, fill: "var(--primary-darker)" },
-];
+import { Skeleton } from "@/components/ui/skeleton";
+import { buildTeamPieData } from "../lib/overview-data";
 
 const chartConfig = {
-  visitors: {
-    label: "Visitors",
+  members: {
+    label: "Members",
   },
-  chrome: {
-    label: "Chrome",
-    color: "var(--primary)",
+  Owner: {
+    label: "Owner",
+    color: "var(--chart-1)",
   },
-  safari: {
-    label: "Safari",
-    color: "var(--primary)",
+  Admin: {
+    label: "Admins",
+    color: "var(--chart-2)",
   },
-  firefox: {
-    label: "Firefox",
-    color: "var(--primary)",
-  },
-  edge: {
-    label: "Edge",
-    color: "var(--primary)",
-  },
-  other: {
-    label: "Other",
-    color: "var(--primary)",
+  Staff: {
+    label: "Staff",
+    color: "var(--chart-3)",
   },
 } satisfies ChartConfig;
 
+function EmptyStateCard({ title, description }: { title: string; description: string }) {
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex min-h-[220px] items-center justify-center">
+        <div className="text-muted-foreground flex flex-col items-center gap-2 text-sm">
+          <Users className="size-5" />
+          <span>No team data to show</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 export function PieGraph() {
-  const totalVisitors = React.useMemo(() => {
-    return chartData.reduce((acc, curr) => acc + curr.visitors, 0);
-  }, []);
+  const { selectedBrewery, breweryLoading, beersLoading } = useBreweryContext();
+
+  const chartData = useMemo(() => buildTeamPieData(selectedBrewery), [selectedBrewery]);
+  const totalMembers = chartData.reduce((acc, curr) => acc + curr.members, 0);
+
+  if (breweryLoading || beersLoading) {
+    return (
+      <Card className="@container/card">
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-56" />
+        </CardHeader>
+        <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
+          <Skeleton className="mx-auto h-[250px] w-[250px] rounded-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!selectedBrewery) {
+    return (
+      <EmptyStateCard
+        title="Team access mix"
+        description="Select a brewery to see how ownership, admin, and staff access is distributed."
+      />
+    );
+  }
+
+  if (!chartData.length) {
+    return (
+      <EmptyStateCard
+        title="Team access mix"
+        description="No team members are attached to this brewery yet."
+      />
+    );
+  }
 
   return (
     <Card className="@container/card">
       <CardHeader>
-        <CardTitle>Pie Chart - Donut with Text</CardTitle>
+        <CardTitle>Team access mix</CardTitle>
         <CardDescription>
-          <span className="hidden @[540px]/card:block">
-            Total visitors by browser for the last 6 months
-          </span>
-          <span className="@[540px]/card:hidden">Browser distribution</span>
+          Owner, admin, and staff membership for the selected brewery
         </CardDescription>
       </CardHeader>
       <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
@@ -76,42 +109,11 @@ export function PieGraph() {
           className="mx-auto aspect-square h-[250px]"
         >
           <PieChart>
-            <defs>
-              {["chrome", "safari", "firefox", "edge", "other"].map(
-                (browser, index) => (
-                  <linearGradient
-                    key={browser}
-                    id={`fill${browser}`}
-                    x1="0"
-                    y1="0"
-                    x2="0"
-                    y2="1"
-                  >
-                    <stop
-                      offset="0%"
-                      stopColor="var(--primary)"
-                      stopOpacity={1 - index * 0.15}
-                    />
-                    <stop
-                      offset="100%"
-                      stopColor="var(--primary)"
-                      stopOpacity={0.8 - index * 0.15}
-                    />
-                  </linearGradient>
-                )
-              )}
-            </defs>
-            <ChartTooltip
-              cursor={false}
-              content={<ChartTooltipContent hideLabel />}
-            />
+            <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
             <Pie
-              data={chartData.map((item) => ({
-                ...item,
-                fill: `url(#fill${item.browser})`,
-              }))}
-              dataKey="visitors"
-              nameKey="browser"
+              data={chartData}
+              dataKey="members"
+              nameKey="role"
               innerRadius={60}
               strokeWidth={2}
               stroke="var(--background)"
@@ -131,14 +133,14 @@ export function PieGraph() {
                           y={viewBox.cy}
                           className="fill-foreground text-3xl font-bold"
                         >
-                          {totalVisitors.toLocaleString()}
+                          {totalMembers.toLocaleString()}
                         </tspan>
                         <tspan
                           x={viewBox.cx}
                           y={(viewBox.cy || 0) + 24}
                           className="fill-muted-foreground text-sm"
                         >
-                          Total Visitors
+                          Members
                         </tspan>
                       </text>
                     );
@@ -149,15 +151,8 @@ export function PieGraph() {
           </PieChart>
         </ChartContainer>
       </CardContent>
-      <CardFooter className="flex-col gap-2 text-sm">
-        <div className="flex items-center gap-2 leading-none font-medium">
-          Chrome leads with{" "}
-          {((chartData[0].visitors / totalVisitors) * 100).toFixed(1)}%{" "}
-          <TrendingUp className="h-4 w-4" />
-        </div>
-        <div className="text-muted-foreground leading-none">
-          Based on data from January - June 2024
-        </div>
+      <CardFooter className="text-muted-foreground text-sm">
+        Role counts are deduplicated across owner, admin, and staff lists.
       </CardFooter>
     </Card>
   );

--- a/src/features/overview/components/recent-sales.tsx
+++ b/src/features/overview/components/recent-sales.tsx
@@ -1,101 +1,118 @@
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+"use client";
+
+import { useMemo } from "react";
+import { Beer } from "lucide-react";
+
+import { useBreweryContext } from "@/context/brewery-beer";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Card,
-  CardHeader,
   CardContent,
+  CardDescription,
+  CardHeader,
   CardTitle,
-  CardDescription
-} from '@/components/ui/card';
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { buildRecentBeerData } from "../lib/overview-data";
 
-export function RecentSales() {
+function EmptyStateCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Recent Sales</CardTitle>
-        <CardDescription>You made 265 sales this month.</CardDescription>
+        <CardTitle>Newest beers</CardTitle>
+        <CardDescription>
+          Added beers will appear here once the selected brewery has data.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex min-h-[220px] items-center justify-center">
+        <div className="text-muted-foreground flex flex-col items-center gap-2 text-sm">
+          <Beer className="size-5" />
+          <span>No recent beers yet</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function RecentSales() {
+  const { selectedBrewery, selectedBeers, breweryLoading, beersLoading } =
+    useBreweryContext();
+
+  const recentBeers = useMemo(
+    () => buildRecentBeerData(selectedBeers),
+    [selectedBeers]
+  );
+
+  if (breweryLoading || beersLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-40" />
+          <Skeleton className="h-4 w-56" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <div key={index} className="flex items-center">
+                <Skeleton className="h-9 w-9 rounded-full" />
+                <div className="ml-4 space-y-1">
+                  <Skeleton className="h-4 w-[120px]" />
+                  <Skeleton className="h-4 w-[160px]" />
+                </div>
+                <Skeleton className="ml-auto h-4 w-[80px]" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!selectedBrewery) {
+    return <EmptyStateCard />;
+  }
+
+  if (!recentBeers.length) {
+    return <EmptyStateCard />;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Newest beers</CardTitle>
+        <CardDescription>
+          Latest additions for {selectedBrewery.companyName}
+        </CardDescription>
       </CardHeader>
       <CardContent>
-        <div className='space-y-8'>
-          <div className='flex items-center'>
-            <Avatar className='h-9 w-9'>
-              <AvatarImage
-                src='https://api.slingacademy.com/public/sample-users/1.png'
-                alt='Avatar'
-              />
-              <AvatarFallback>OM</AvatarFallback>
-            </Avatar>
-            <div className='ml-4 space-y-1'>
-              <p className='text-sm font-medium leading-none'>Olivia Martin</p>
-              <p className='text-sm text-muted-foreground'>
-                olivia.martin@email.com
-              </p>
+        <div className="space-y-8">
+          {recentBeers.map((beer) => (
+            <div key={beer.id} className="flex items-center">
+              <Avatar className="h-9 w-9">
+                {beer.avatar ? (
+                  <AvatarImage src={beer.avatar} alt={beer.name} />
+                ) : null}
+                <AvatarFallback>{beer.initials}</AvatarFallback>
+              </Avatar>
+              <div className="ml-4 min-w-0 space-y-1">
+                <p className="truncate text-sm font-medium leading-none">
+                  {beer.name}
+                </p>
+                <p className="text-muted-foreground text-sm">
+                  {beer.style} {beer.createdAt ? `• ${beer.createdAt}` : ""}
+                </p>
+              </div>
+              <div className="ml-auto flex items-center gap-2">
+                {beer.archived ? <Badge variant="outline">Archived</Badge> : null}
+                <span className="font-medium tabular-nums">
+                  {typeof beer.abv === "number"
+                    ? `${beer.abv.toFixed(1)}% ABV`
+                    : "ABV n/a"}
+                </span>
+              </div>
             </div>
-            <div className='ml-auto font-medium'>+$1,999.00</div>
-          </div>
-          <div className='flex items-center'>
-            <Avatar className='flex h-9 w-9 items-center justify-center space-y-0 border'>
-              <AvatarImage
-                src='https://api.slingacademy.com/public/sample-users/2.png'
-                alt='Avatar'
-              />
-              <AvatarFallback>JL</AvatarFallback>
-            </Avatar>
-            <div className='ml-4 space-y-1'>
-              <p className='text-sm font-medium leading-none'>Jackson Lee</p>
-              <p className='text-sm text-muted-foreground'>
-                jackson.lee@email.com
-              </p>
-            </div>
-            <div className='ml-auto font-medium'>+$39.00</div>
-          </div>
-          <div className='flex items-center'>
-            <Avatar className='h-9 w-9'>
-              <AvatarImage
-                src='https://api.slingacademy.com/public/sample-users/3.png'
-                alt='Avatar'
-              />
-              <AvatarFallback>IN</AvatarFallback>
-            </Avatar>
-            <div className='ml-4 space-y-1'>
-              <p className='text-sm font-medium leading-none'>
-                Isabella Nguyen
-              </p>
-              <p className='text-sm text-muted-foreground'>
-                isabella.nguyen@email.com
-              </p>
-            </div>
-            <div className='ml-auto font-medium'>+$299.00</div>
-          </div>
-          <div className='flex items-center'>
-            <Avatar className='h-9 w-9'>
-              <AvatarImage
-                src='https://api.slingacademy.com/public/sample-users/4.png'
-                alt='Avatar'
-              />
-              <AvatarFallback>WK</AvatarFallback>
-            </Avatar>
-            <div className='ml-4 space-y-1'>
-              <p className='text-sm font-medium leading-none'>William Kim</p>
-              <p className='text-sm text-muted-foreground'>will@email.com</p>
-            </div>
-            <div className='ml-auto font-medium'>+$99.00</div>
-          </div>
-          <div className='flex items-center'>
-            <Avatar className='h-9 w-9'>
-              <AvatarImage
-                src='https://api.slingacademy.com/public/sample-users/5.png'
-                alt='Avatar'
-              />
-              <AvatarFallback>SD</AvatarFallback>
-            </Avatar>
-            <div className='ml-4 space-y-1'>
-              <p className='text-sm font-medium leading-none'>Sofia Davis</p>
-              <p className='text-sm text-muted-foreground'>
-                sofia.davis@email.com
-              </p>
-            </div>
-            <div className='ml-auto font-medium'>+$39.00</div>
-          </div>
+          ))}
         </div>
       </CardContent>
     </Card>

--- a/src/features/overview/lib/overview-data.ts
+++ b/src/features/overview/lib/overview-data.ts
@@ -1,0 +1,270 @@
+import { Beer } from "@/types/beer";
+import { Brewery } from "@/types/brewery";
+
+type BreweryMember =
+  | string
+  | number
+  | {
+      _id?: string;
+      fullName?: string;
+      username?: string;
+      email?: string;
+      image?: string;
+    };
+
+export type OverviewMetric = {
+  label: string;
+  value: string;
+  description: string;
+};
+
+export type OverviewBarDatum = {
+  category: string;
+  beers: number;
+};
+
+export type OverviewAreaDatum = {
+  month: string;
+  beers: number;
+};
+
+export type OverviewPieDatum = {
+  role: string;
+  members: number;
+  fill: string;
+};
+
+export type OverviewRecentBeer = {
+  id: string;
+  name: string;
+  style: string;
+  abv: number;
+  createdAt: string;
+  archived: boolean;
+  avatar: string;
+  initials: string;
+};
+
+const MONTH_WINDOW = 6;
+
+function getMemberId(member: BreweryMember | null | undefined) {
+  if (!member) return null;
+  if (typeof member === "string" || typeof member === "number") {
+    return String(member);
+  }
+  return member._id ?? member.email ?? member.username ?? member.fullName ?? null;
+}
+
+function getMemberInitials(label: string) {
+  const parts = label
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "");
+
+  return parts.join("") || "BF";
+}
+
+function formatMonthKey(date: Date) {
+  return `${date.getFullYear()}-${date.getMonth()}`;
+}
+
+function formatMonthLabel(date: Date) {
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    year: "2-digit",
+  });
+}
+
+function toDate(value: Beer["createdAt"]) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function toBeerLabel(beer: Beer) {
+  return beer.name || beer.style || "Beer";
+}
+
+export function buildOverviewMetrics(
+  brewery: Brewery | null,
+  beers: Beer[] | null
+): OverviewMetric[] {
+  const beerList = beers ?? [];
+  const activeBeers = beerList.filter((beer) => !beer.archived);
+  const archivedBeers = beerList.filter((beer) => beer.archived);
+  const categoriesConfigured = brewery?.categories?.length ?? 0;
+  const averageAbv =
+    beerList.length > 0
+      ? beerList.reduce((acc, beer) => acc + (beer.abv || 0), 0) /
+        beerList.length
+      : 0;
+
+  return [
+    {
+      label: "Beer catalog",
+      value: beerList.length.toLocaleString(),
+      description: `${activeBeers.length} active, ${archivedBeers.length} archived`,
+    },
+    {
+      label: "Active beers",
+      value: activeBeers.length.toLocaleString(),
+      description: "Currently shown in the brewery catalog",
+    },
+    {
+      label: "Categories",
+      value: categoriesConfigured.toLocaleString(),
+      description: "Configured brewery categories",
+    },
+    {
+      label: "Average ABV",
+      value: `${averageAbv.toFixed(1)}%`,
+      description: "Across the selected brewery's beer catalog",
+    },
+  ];
+}
+
+export function buildCategoryBarData(
+  brewery: Brewery | null,
+  beers: Beer[] | null
+): OverviewBarDatum[] {
+  const beerList = beers ?? [];
+  const categoryCounts = new Map<string, number>();
+
+  brewery?.categories?.forEach((category) => {
+    categoryCounts.set(category.name, 0);
+  });
+
+  let uncategorized = 0;
+
+  for (const beer of beerList) {
+    const assigned = beer.category ?? [];
+    if (!assigned.length) {
+      uncategorized += 1;
+      continue;
+    }
+
+    for (const category of assigned) {
+      const current = categoryCounts.get(category.name) ?? 0;
+      categoryCounts.set(category.name, current + 1);
+    }
+  }
+
+  const categoryData = Array.from(categoryCounts.entries())
+    .filter(([, beersCount]) => beersCount > 0)
+    .map(([category, beersCount]) => ({
+      category,
+      beers: beersCount,
+    }))
+    .sort((left, right) => right.beers - left.beers);
+
+  if (uncategorized > 0) {
+    categoryData.push({
+      category: "Uncategorized",
+      beers: uncategorized,
+    });
+  }
+
+  return categoryData.slice(0, 8);
+}
+
+export function buildMonthlyBeerData(beers: Beer[] | null): OverviewAreaDatum[] {
+  const beerList = beers ?? [];
+  const months = Array.from({ length: MONTH_WINDOW }, (_, index) => {
+    const date = new Date();
+    date.setDate(1);
+    date.setHours(0, 0, 0, 0);
+    date.setMonth(date.getMonth() - (MONTH_WINDOW - 1 - index));
+
+    return {
+      key: formatMonthKey(date),
+      month: formatMonthLabel(date),
+      beers: 0,
+    };
+  });
+
+  const monthLookup = new Map(months.map((month) => [month.key, month]));
+
+  for (const beer of beerList) {
+    const date = toDate(beer.createdAt);
+    if (!date) continue;
+
+    const key = formatMonthKey(date);
+    const month = monthLookup.get(key);
+    if (month) {
+      month.beers += 1;
+    }
+  }
+
+  return months.map(({ month, beers }) => ({ month, beers }));
+}
+
+export function buildTeamPieData(brewery: Brewery | null): OverviewPieDatum[] {
+  const seen = new Set<string>();
+  const take = (role: string, members: BreweryMember[] | undefined, fill: string) => {
+    const count =
+      members?.reduce((acc, member) => {
+        const memberId = getMemberId(member);
+        if (!memberId || seen.has(memberId)) {
+          return acc;
+        }
+
+        seen.add(memberId);
+        return acc + 1;
+      }, 0) ?? 0;
+
+    return count > 0 ? { role, members: count, fill } : null;
+  };
+
+  const output = [
+    take("Owner", brewery?.owner ? [brewery.owner as BreweryMember] : [], "var(--chart-1)"),
+    take("Admin", brewery?.admin as BreweryMember[] | undefined, "var(--chart-2)"),
+    take("Staff", brewery?.staff as BreweryMember[] | undefined, "var(--chart-3)"),
+  ].filter(Boolean) as OverviewPieDatum[];
+
+  return output;
+}
+
+export function buildRecentBeerData(
+  beers: Beer[] | null
+): OverviewRecentBeer[] {
+  return (beers ?? [])
+    .slice()
+    .sort((left, right) => {
+      const leftDate = toDate(left.createdAt)?.getTime() ?? 0;
+      const rightDate = toDate(right.createdAt)?.getTime() ?? 0;
+      return rightDate - leftDate;
+    })
+    .slice(0, 5)
+    .map((beer) => {
+      const label = toBeerLabel(beer);
+      return {
+        id: beer._id,
+        name: label,
+        style: beer.style || "Unstyled beer",
+        abv: beer.abv || 0,
+        createdAt: toDate(beer.createdAt)?.toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+        }) ?? "Unknown date",
+        archived: beer.archived,
+        avatar: beer.image || "",
+        initials: getMemberInitials(label),
+      };
+    });
+}
+
+export function getOverviewContextState(
+  brewery: Brewery | null,
+  beers: Beer[] | null
+) {
+  return {
+    hasBrewery: Boolean(brewery),
+    hasBeers: Boolean(beers),
+    metrics: buildOverviewMetrics(brewery, beers),
+    categoryBars: buildCategoryBarData(brewery, beers),
+    monthlyBeers: buildMonthlyBeerData(beers),
+    teamPie: buildTeamPieData(brewery),
+    recentBeers: buildRecentBeerData(beers),
+  };
+}

--- a/src/lib/PUT/updateUserNotfications.tsx
+++ b/src/lib/PUT/updateUserNotfications.tsx
@@ -29,10 +29,15 @@ export default async function updateUserNotifications({
 
       // Check if the response is not ok (non-2xx status code)
       if (!response.ok) {
-        const errorData = await response.json(); // Parse the JSON response to get the error message
-        console.error(errorData);
-        alert(errorData.error); // Display the error message
-        throw new Error(errorData.error);
+        let errorMessage = "Unable to update notification preferences.";
+        try {
+          const errorData = await response.json();
+          errorMessage =
+            errorData?.error || errorData?.message || errorMessage;
+        } catch {
+          // Keep the fallback message when the API does not return JSON.
+        }
+        throw new Error(errorMessage);
       }
 
       const responseData: Users = await response.json();

--- a/src/lib/handleSubmit/handleCreateBeer.tsx
+++ b/src/lib/handleSubmit/handleCreateBeer.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import createBeer from "@/lib/createBeer";
+import saveImage from "@/lib/supabase/saveImage";
+import { Brewery } from "@/types/brewery";
+import { Beer, NewBeer } from "@/types/beer";
+import { FormValues } from "@/components/CreateBeerForm/types";
+
+const toCategoryNames = (categories: FormValues["category"]) =>
+  categories.map((category) =>
+    typeof category === "string" ? category : category.name
+  );
+
+const handleCreateBeer = async (
+  values: FormValues,
+  brewery: Brewery,
+  accessToken?: string
+) => {
+  const image =
+    values.image instanceof File
+      ? await saveImage({ file: values.image })
+      : typeof values.image === "string"
+        ? values.image
+        : "";
+
+  const newBeer: NewBeer = {
+    _id: values._id,
+    name: values.name,
+    style: values.style,
+    image: image || "",
+    abv: Number(values.abv || 0),
+    ibu: Number(values.ibu || 0),
+    category: toCategoryNames(values.category),
+    malt: values.malt ?? [],
+    hops: values.hops ?? [],
+    description: values.description ?? "",
+    nameSake: values.nameSake ?? "",
+    notes: values.notes ?? "",
+    archived: values.archived,
+    releasedOn: values.releasedOn || null,
+  };
+
+  // createBeer reads the authenticated brewery from the session server-side.
+  void brewery;
+  void accessToken;
+
+  const createdBeer = await createBeer(newBeer);
+  return createdBeer as Beer | null;
+};
+
+export default handleCreateBeer;

--- a/src/lib/import/beerImport.ts
+++ b/src/lib/import/beerImport.ts
@@ -1,0 +1,526 @@
+import moment from "moment";
+import blueprint from "@/flatfile/blueprint";
+import { buildApiUrl } from "@/lib/api/base";
+import type { Beer, NewBeer } from "@/types/beer";
+import type { Category } from "@/types/category";
+
+type BeerImportCsvRow = Record<string, string>;
+
+type BeerImportFieldValue = string | number | boolean | null;
+
+export type BeerImportNormalizedRow = {
+  name: string;
+  style: string;
+  abv: number | null;
+  ibu: number | null;
+  category: string[];
+  malt: string[];
+  hops: string[];
+  description: string;
+  nameSake: string;
+  notes: string;
+  releasedOn: string | null;
+  archived: boolean;
+};
+
+export type BeerImportFailure = {
+  rowNumber: number;
+  message: string;
+  beerName?: string;
+};
+
+export type BeerImportSummary = {
+  createdCount: number;
+  failedCount: number;
+  totalCount: number;
+  failures: BeerImportFailure[];
+};
+
+const importFields = blueprint.fields as Array<{ key: string; label: string }>;
+
+const headerLabels = importFields.map((field) => field.label);
+
+const headerLookup = new Map(
+  importFields.flatMap((field) => [
+    [normalizeBeerImportKey(field.key), field.key],
+    [normalizeBeerImportKey(field.label), field.key],
+  ])
+);
+
+const dateFormats = [
+  "MM/DD/YYYY",
+  "M/D/YYYY",
+  "M/D/YY",
+  "YYYY-MM-DD",
+  "MMMM Do, YYYY",
+  "MMM D, YYYY",
+];
+
+export function normalizeBeerImportKey(value: string) {
+  return value.trim().toLowerCase().replace(/[\s_]+/g, "");
+}
+
+function normalizeCellValue(value: unknown) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  return String(value).trim();
+}
+
+function getRecordValue(record: BeerImportCsvRow, key: string) {
+  const normalizedKey = normalizeBeerImportKey(key);
+  const directValue = record[key];
+
+  if (directValue !== undefined && directValue !== null) {
+    return directValue;
+  }
+
+  for (const [recordKey, value] of Object.entries(record)) {
+    if (normalizeBeerImportKey(recordKey) === normalizedKey) {
+      return value;
+    }
+  }
+
+  const headerKey = headerLookup.get(normalizedKey);
+  if (headerKey) {
+    return record[headerKey] ?? "";
+  }
+
+  return "";
+}
+
+function splitListField(value: string) {
+  return value
+    .split(/[,;\n|]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseNumberField(
+  value: string,
+  fieldLabel: string,
+  required = false
+): { value: number | null; error?: string } {
+  if (!value) {
+    return required
+      ? { value: null, error: `${fieldLabel} is required.` }
+      : { value: null };
+  }
+
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) {
+    return { value: null, error: `${fieldLabel} must be a number.` };
+  }
+
+  return { value: parsed };
+}
+
+function parseBooleanField(
+  value: string,
+  fieldLabel: string
+): { value: boolean; error?: string } {
+  const normalized = value.trim().toLowerCase();
+
+  if (!normalized) {
+    return { value: false };
+  }
+
+  if (["true", "yes", "y", "1"].includes(normalized)) {
+    return { value: true };
+  }
+
+  if (["false", "no", "n", "0"].includes(normalized)) {
+    return { value: false };
+  }
+
+  return {
+    value: false,
+    error: `${fieldLabel} must be a boolean value.`,
+  };
+}
+
+function parseDateField(value: string) {
+  if (!value) {
+    return { value: null as string | null };
+  }
+
+  const parsed = moment(value, dateFormats, true);
+
+  if (!parsed.isValid()) {
+    return {
+      value: null as string | null,
+      error: "Release Date must be a valid date.",
+    };
+  }
+
+  return { value: parsed.format("YYYY-MM-DD") };
+}
+
+function escapeCsvValue(value: BeerImportFieldValue) {
+  const stringValue =
+    value === null || value === undefined ? "" : String(value);
+  return `"${stringValue.replace(/"/g, '""')}"`;
+}
+
+function toCsv(rows: BeerImportFieldValue[][]) {
+  return rows.map((row) => row.map(escapeCsvValue).join(",")).join("\n");
+}
+
+export function buildBeerImportTemplateCsv() {
+  const exampleRows = [
+    [
+      "Example Beer Name",
+      "IPA",
+      "7.5",
+      "70",
+      "Hoppy",
+      "Malt1, Malt2",
+      "Hop1, Hop2",
+      "Freshest of the fresh hops",
+      "One that was made up by the great master minds",
+      "Double dry hopped with Citra and Mosaic",
+      "2019-03-05",
+      "false",
+    ],
+    [
+      "Another Beer Name",
+      "Stout",
+      "5.6",
+      "30",
+      "Dark & Malty",
+      "Malt1, Malt2",
+      "Hop1, Hop2",
+      "Dark chocolatey and delicious",
+      "One that was made up by the great master minds again",
+      "Collaboration with the brewery down the street",
+      "2019-03-05",
+      "true",
+    ],
+  ];
+
+  return toCsv([headerLabels, ...exampleRows]);
+}
+
+export function buildBeerExportCsv(beers: Beer[]) {
+  const rows = beers.map((beer) => [
+    beer.name,
+    beer.style,
+    beer.abv ?? "",
+    beer.ibu ?? "",
+    beer.category?.map((category) => category.name).join(", ") ?? "",
+    beer.malt?.join(", ") ?? "",
+    beer.hops?.join(", ") ?? "",
+    beer.description ?? "",
+    beer.nameSake ?? "",
+    beer.notes ?? "",
+    beer.releasedOn ? moment(beer.releasedOn).format("YYYY-MM-DD") : "",
+    beer.archived ? "true" : "false",
+  ]);
+
+  return toCsv([headerLabels, ...rows]);
+}
+
+export function createBeerCategoryCache(
+  breweryCategories: Array<{ name: string; _id?: string }>
+) {
+  const cache = new Map<string, string>();
+
+  breweryCategories
+    .filter((category): category is { name: string; _id: string } =>
+      Boolean(category._id)
+    )
+    .forEach((category) => {
+      cache.set(normalizeBeerImportKey(category.name), category._id);
+    });
+
+  return cache;
+}
+
+export function parseBeerImportCsv(csvText: string) {
+  const normalized = csvText
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentValue = "";
+  let inQuotes = false;
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const nextChar = normalized[index + 1];
+
+    if (inQuotes) {
+      if (char === '"' && nextChar === '"') {
+        currentValue += '"';
+        index += 1;
+        continue;
+      }
+
+      if (char === '"') {
+        inQuotes = false;
+        continue;
+      }
+
+      currentValue += char;
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+      continue;
+    }
+
+    if (char === ",") {
+      currentRow.push(currentValue);
+      currentValue = "";
+      continue;
+    }
+
+    if (char === "\n") {
+      currentRow.push(currentValue);
+      rows.push(currentRow);
+      currentRow = [];
+      currentValue = "";
+      continue;
+    }
+
+    currentValue += char;
+  }
+
+  if (currentValue.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentValue);
+    rows.push(currentRow);
+  }
+
+  const [rawHeaders = [], ...rawRows] = rows;
+  const headers = rawHeaders.map((header) => header.trim());
+
+  return rawRows
+    .filter((row) => row.some((cell) => cell.trim().length > 0))
+    .map((row) => {
+      const record: BeerImportCsvRow = {};
+      headers.forEach((header, index) => {
+        record[header] = normalizeCellValue(row[index]);
+      });
+      return record;
+    });
+}
+
+export function normalizeBeerImportRow(record: BeerImportCsvRow) {
+  const errors: string[] = [];
+
+  const name = normalizeCellValue(
+    getRecordValue(record, "name") ?? getRecordValue(record, "Name")
+  );
+  const style = normalizeCellValue(
+    getRecordValue(record, "style") ?? getRecordValue(record, "Style")
+  );
+  const categoryRaw = normalizeCellValue(
+    getRecordValue(record, "category") ?? getRecordValue(record, "Category")
+  );
+  const malt = splitListField(
+    normalizeCellValue(getRecordValue(record, "malts") ?? getRecordValue(record, "Malts"))
+  );
+  const hops = splitListField(
+    normalizeCellValue(getRecordValue(record, "hops") ?? getRecordValue(record, "Hops"))
+  );
+  const description = normalizeCellValue(
+    getRecordValue(record, "description") ??
+      getRecordValue(record, "Description")
+  );
+  const nameSake = normalizeCellValue(
+    getRecordValue(record, "name_sake") ??
+      getRecordValue(record, "nameSake") ??
+      getRecordValue(record, "Name Sake")
+  );
+  const notes = normalizeCellValue(
+    getRecordValue(record, "notes") ?? getRecordValue(record, "Notes")
+  );
+  const releaseDateRaw = normalizeCellValue(
+    getRecordValue(record, "release_date") ??
+      getRecordValue(record, "releasedOn") ??
+      getRecordValue(record, "Release Date")
+  );
+  const archivedRaw = normalizeCellValue(
+    getRecordValue(record, "archived") ?? getRecordValue(record, "Archived")
+  );
+
+  if (!name) {
+    errors.push("Name is required.");
+  }
+
+  if (!style) {
+    errors.push("Style is required.");
+  }
+
+  const category = splitListField(categoryRaw);
+  if (category.length === 0) {
+    errors.push("Category is required.");
+  }
+
+  const abvField = parseNumberField(
+    normalizeCellValue(getRecordValue(record, "abv") ?? getRecordValue(record, "ABV")),
+    "ABV",
+    true
+  );
+  if (abvField.error) {
+    errors.push(abvField.error);
+  }
+
+  const ibuField = parseNumberField(
+    normalizeCellValue(getRecordValue(record, "ibu") ?? getRecordValue(record, "IBU")),
+    "IBU"
+  );
+  if (ibuField.error) {
+    errors.push(ibuField.error);
+  }
+
+  const releaseDateField = parseDateField(releaseDateRaw);
+  if (releaseDateField.error) {
+    errors.push(releaseDateField.error);
+  }
+
+  const archivedField = parseBooleanField(archivedRaw, "Archived");
+  if (archivedField.error) {
+    errors.push(archivedField.error);
+  }
+
+  if (errors.length > 0) {
+    return {
+      value: null,
+      errors,
+    };
+  }
+
+  return {
+    value: {
+      name,
+      style,
+      abv: abvField.value,
+      ibu: ibuField.value,
+      category,
+      malt,
+      hops,
+      description,
+      nameSake,
+      notes,
+      releasedOn: releaseDateField.value,
+      archived: archivedField.value,
+    } satisfies BeerImportNormalizedRow,
+    errors: [],
+  };
+}
+
+export async function resolveBeerCategoryIds({
+  breweryId,
+  accessToken,
+  categoryCache,
+  categoryNames,
+}: {
+  breweryId: string;
+  accessToken: string;
+  categoryCache: Map<string, string>;
+  categoryNames: string[];
+}) {
+  const categoryIds: string[] = [];
+  const seenCategoryKeys = new Set<string>();
+
+  for (const categoryName of categoryNames) {
+    const normalizedCategoryName = normalizeBeerImportKey(categoryName);
+    if (seenCategoryKeys.has(normalizedCategoryName)) {
+      continue;
+    }
+
+    seenCategoryKeys.add(normalizedCategoryName);
+    const existingId = categoryCache.get(normalizedCategoryName);
+
+    if (existingId) {
+      categoryIds.push(existingId);
+      continue;
+    }
+
+    // Best effort: reuse brewery categories when possible, then create missing
+    // categories through the existing endpoint instead of inventing ids.
+    const createdCategory = await createBeerCategory({
+      breweryId,
+      accessToken,
+      categoryName,
+    });
+
+    categoryCache.set(normalizedCategoryName, createdCategory._id);
+    categoryIds.push(createdCategory._id);
+  }
+
+  return categoryIds;
+}
+
+export async function createBeerCategory({
+  breweryId,
+  accessToken,
+  categoryName,
+}: {
+  breweryId: string;
+  accessToken: string;
+  categoryName: string;
+}) {
+  const response = await fetch(
+    buildApiUrl(`/breweries/${breweryId}/categories`),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ name: categoryName }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response, "Failed to create category"));
+  }
+
+  return (await response.json()) as Category;
+}
+
+export async function createBeerForBrewery({
+  breweryId,
+  accessToken,
+  beer,
+}: {
+  breweryId: string;
+  accessToken: string;
+  beer: NewBeer;
+}) {
+  const response = await fetch(buildApiUrl(`/breweries/${breweryId}/beers`), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(beer),
+  });
+
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response, "Failed to create beer"));
+  }
+
+  return (await response.json()) as Beer;
+}
+
+async function readApiErrorMessage(response: Response, fallbackMessage: string) {
+  try {
+    const errorData = await response.json();
+    if (typeof errorData?.message === "string" && errorData.message.trim()) {
+      return errorData.message;
+    }
+  } catch {
+    const text = await response.text().catch(() => "");
+    if (text.trim()) {
+      return text;
+    }
+  }
+
+  return fallbackMessage;
+}


### PR DESCRIPTION
## Summary
- add the product remediation plan document
- make Flatfile CSV import persist beers through existing brewery beer/category endpoints
- add brewery beer CSV export and template download flows
- add post-create beer share actions for view/copy/create another
- replace placeholder overview metrics/charts/lists with real brewery-derived data
- improve notification settings UX with email/push toggles plus save/error status

## Verification
- `pnpm lint` ✅ passed with existing React hook warnings
- `pnpm build` ✅ passed

## Notes
- Existing build warning remains: `BeerViewDialog` is imported from `./dialogs/beer-dialog-wrapper` but not exported there.
- Manual smoke QA is still recommended for import/export round trip, create/share actions, overview data with real brewery state, and notification preference saving.
